### PR TITLE
feat: add MSRP field to products

### DIFF
--- a/apps/web/src/components/products/product-form.tsx
+++ b/apps/web/src/components/products/product-form.tsx
@@ -64,6 +64,7 @@ const schema = z.object({
   targetStockLevel: z.coerce.number().int().min(0).optional(),
   leadTimeDays: z.coerce.number().int().min(0).optional(),
   unitCost: z.coerce.number().min(0).optional(),
+  msrp: z.coerce.number().min(0).optional(),
   imageUrl: z.string().url("Must be a valid URL").optional().or(z.literal("")),
   notes: z.string().optional(),
   isActive: z.boolean().default(true),
@@ -136,6 +137,7 @@ export function ProductForm({
       targetStockLevel: undefined,
       leadTimeDays: undefined,
       unitCost: undefined,
+      msrp: undefined,
       imageUrl: "",
       notes: "",
       isActive: true,
@@ -162,6 +164,7 @@ export function ProductForm({
           targetStockLevel: initialProduct.targetStockLevel ?? undefined,
           leadTimeDays: initialProduct.leadTimeDays ?? undefined,
           unitCost: initialProduct.unitCost ?? undefined,
+          msrp: initialProduct.msrp ?? undefined,
           imageUrl: initialProduct.imageUrl ?? "",
           notes: initialProduct.notes ?? "",
           isActive: initialProduct.isActive ?? true,
@@ -182,6 +185,7 @@ export function ProductForm({
           targetStockLevel: initialProduct.targetStockLevel ?? undefined,
           leadTimeDays: initialProduct.leadTimeDays ?? undefined,
           unitCost: initialProduct.unitCost ?? undefined,
+          msrp: initialProduct.msrp ?? undefined,
           imageUrl: initialProduct.imageUrl ?? "",
           notes: initialProduct.notes ?? "",
           isActive: initialProduct.isActive ?? true,
@@ -273,6 +277,7 @@ export function ProductForm({
       targetStockLevel: values.targetStockLevel,
       leadTimeDays: values.leadTimeDays,
       unitCost: values.unitCost,
+      msrp: values.msrp,
       imageUrl,
       notes: values.notes || undefined,
       isActive: values.isActive,
@@ -643,20 +648,38 @@ export function ProductForm({
                 </div>
 
                 {canViewCosts && (
-                  <div className="grid gap-2">
-                    <Label htmlFor="unitCost">
-                      Unit Cost{" "}
-                      <span className="text-muted-foreground font-normal">
-                        (optional)
-                      </span>
-                    </Label>
-                    <Input
-                      id="unitCost"
-                      type="number"
-                      step="0.01"
-                      placeholder="0.00"
-                      {...form.register("unitCost")}
-                    />
+                  <div className="space-y-4">
+                    <div className="grid gap-2">
+                      <Label htmlFor="unitCost">
+                        Unit Cost{" "}
+                        <span className="text-muted-foreground font-normal">
+                          (optional)
+                        </span>
+                      </Label>
+                      <Input
+                        id="unitCost"
+                        type="number"
+                        step="0.01"
+                        placeholder="0.00"
+                        {...form.register("unitCost")}
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="msrp">
+                        MSRP{" "}
+                        <span className="text-muted-foreground font-normal">
+                          (optional)
+                        </span>
+                      </Label>
+                      <Input
+                        id="msrp"
+                        type="number"
+                        step="0.01"
+                        placeholder="0.00"
+                        {...form.register("msrp")}
+                      />
+                    </div>
                   </div>
                 )}
               </div>

--- a/apps/web/src/components/products/product-modal.tsx
+++ b/apps/web/src/components/products/product-modal.tsx
@@ -176,6 +176,16 @@ export function ProductModal({
                 </span>
               </div>
             )}
+            {canViewCosts && (
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground text-xs sm:text-sm">
+                  MSRP:
+                </span>
+                <span className="text-xs sm:text-sm">
+                  {formatCurrency(p.msrp)}
+                </span>
+              </div>
+            )}
             {p.preferredSupplierName && (
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground text-xs sm:text-sm">

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -186,6 +186,7 @@ export interface Product {
   targetStockLevel?: number;
   leadTimeDays?: number;
   unitCost?: number;
+  msrp?: number;
   isActive: boolean;
   quantity: number;
   imageUrl?: string;
@@ -207,6 +208,7 @@ export interface ProductRequest {
   targetStockLevel?: number;
   leadTimeDays?: number;
   unitCost?: number;
+  msrp?: number;
   isActive?: boolean;
   imageUrl?: string;
   notes?: string;

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/ProductController.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/ProductController.java
@@ -100,6 +100,7 @@ public class ProductController {
                 requestDTO.getTargetStockLevel(),
                 requestDTO.getLeadTimeDays(),
                 requestDTO.getUnitCost(),
+                requestDTO.getMsrp(),
                 requestDTO.getImageUrl(),
                 requestDTO.getNotes(),
                 requestDTO.getInitialStock()
@@ -127,6 +128,7 @@ public class ProductController {
                 requestDTO.getTargetStockLevel(),
                 requestDTO.getLeadTimeDays(),
                 requestDTO.getUnitCost(),
+                requestDTO.getMsrp(),
                 requestDTO.getImageUrl(),
                 requestDTO.getNotes(),
                 clearParent,

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/requests/ProductRequestDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/requests/ProductRequestDTO.java
@@ -47,6 +47,8 @@ public class ProductRequestDTO {
 
     private BigDecimal unitCost;
 
+    private BigDecimal msrp;
+
     @Pattern(
         regexp = "^(https://[a-zA-Z0-9-]+\\.supabase\\.co/storage/v1/object/public/product-images/[a-zA-Z0-9._-]+)?$",
         message = "Image URL must be from Supabase storage"

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/ProductResponseDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/ProductResponseDTO.java
@@ -41,6 +41,7 @@ public class ProductResponseDTO {
     private UUID lastDeliveredSupplierId;
     private String lastDeliveredSupplierName;
     private BigDecimal unitCost;
+    private BigDecimal msrp;
     private Boolean isActive;
     private Integer quantity;
     private String imageUrl;

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/Product.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/Product.java
@@ -84,6 +84,9 @@ public class Product {
     @Column(name = "unit_cost", precision = 10, scale = 2)
     private BigDecimal unitCost;
 
+    @Column(name = "msrp", precision = 10, scale = 2)
+    private BigDecimal msrp;
+
     @Column(name = "is_active")
     @Builder.Default
     private Boolean isActive = true;

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/ProductService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/ProductService.java
@@ -76,7 +76,7 @@ public class ProductService {
     public Product createProduct(String sku, UUID categoryId, UUID parentId,
                                  String letter, Integer templateQuantity, String name, String description, Integer reorderPoint,
                                  Integer targetStockLevel, Integer leadTimeDays,
-                                 BigDecimal unitCost, String imageUrl, String notes,
+                                 BigDecimal unitCost, BigDecimal msrp, String imageUrl, String notes,
                                  Integer initialStock) {
         // Validate parent if provided
         Product parent = null;
@@ -117,6 +117,7 @@ public class ProductService {
                 .targetStockLevel(targetStockLevel != null ? targetStockLevel : 50)
                 .leadTimeDays(leadTimeDays != null ? leadTimeDays : 14)
                 .unitCost(unitCost)
+                .msrp(msrp)
                 .imageUrl(imageUrl)
                 .notes(notes)
                 .isActive(startsActive)
@@ -193,7 +194,7 @@ public class ProductService {
     public Product updateProduct(UUID id, String sku, UUID categoryId, UUID parentId,
                                  String letter, Integer templateQuantity, String name, String description, Integer reorderPoint,
                                  Integer targetStockLevel, Integer leadTimeDays,
-                                 BigDecimal unitCost, String imageUrl, String notes,
+                                 BigDecimal unitCost, BigDecimal msrp, String imageUrl, String notes,
                                  Boolean clearParent, Integer quantity,
                                  UUID preferredSupplierId, Boolean preferredSupplierAuto,
                                  Boolean clearPreferredSupplier) {
@@ -240,6 +241,7 @@ public class ProductService {
         if (targetStockLevel != null) product.setTargetStockLevel(targetStockLevel);
         if (leadTimeDays != null) product.setLeadTimeDays(leadTimeDays);
         if (unitCost != null) product.setUnitCost(unitCost);
+        if (msrp != null) product.setMsrp(msrp);
         if (imageUrl != null) product.setImageUrl(imageUrl);
         if (notes != null) product.setNotes(notes);
         // Allow direct quantity update only for prize products (products with a parent)


### PR DESCRIPTION
- Add msrp column to Product entity (BigDecimal, precision 10, scale 2)
- Update ProductRequestDTO and ProductResponseDTO with msrp field
- Update ProductService create/update methods to handle msrp
- Add msrp to frontend TypeScript interfaces
- Add MSRP input field to product form (gated by canViewCosts permission)
- Display MSRP in product detail modal below Unit Cost