### PR TITLE
perf(frontend): add browserslist config to eliminate legacy JS polyfills

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -84,5 +84,11 @@
     "tw-animate-css": "1.3.3",
     "typescript": "5.9.3",
     "vitest": "^4.0.18"
-  }
+  },
+  "browserslist": [
+    "chrome 111",
+    "edge 111",
+    "firefox 111",
+    "safari 16.4"
+  ]
 }


### PR DESCRIPTION
- Target modern browsers only (Chrome 111+, Edge 111+, Firefox 111+, Safari 16.4+)
- Eliminates ~14 KiB of unnecessary polyfills for Opera Mini, KaiOS, older Android
- Improves mobile Lighthouse performance score