### PR TITLE
feat(analytics): add recompute rollups button and cost/profit tracking

### DIFF
--- a/apps/web/src/app/(dashboard)/analytics/_components/tab-overview.tsx
+++ b/apps/web/src/app/(dashboard)/analytics/_components/tab-overview.tsx
@@ -20,6 +20,9 @@ import {
 import { cn } from "@/lib/utils";
 import { useInsights } from "@/hooks/queries/use-insights";
 import { useSalesSummary } from "@/hooks/queries/use-analytics";
+import { useRecomputeRollupsMutation } from "@/hooks/mutations/use-analytics-mutations";
+import { usePermissions } from "@/hooks/use-permissions";
+import { useToast } from "@/hooks/use-toast";
 import { SalesMetricsCard } from "@/components/analytics";
 import type { Mover, MoverDirection } from "@/types/analytics";
 import { LongestRunningDisplaysCard } from "./longest-running-displays-card";
@@ -155,6 +158,27 @@ function MoversCard({
 export function TabOverview() {
   const { data: insightsData, isLoading: insightsLoading, isError } = useInsights();
   const { data: salesData, isLoading: salesLoading } = useSalesSummary();
+  const { isAdmin } = usePermissions();
+  const { toast } = useToast();
+  const recomputeMutation = useRecomputeRollupsMutation();
+
+  const handleRecomputeRollups = () => {
+    recomputeMutation.mutate(undefined, {
+      onSuccess: (data) => {
+        toast({
+          title: "Sales data recomputed",
+          description: `Refreshed ${data.rollupsRecomputed.toLocaleString()} daily records.`,
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: "Recomputation failed",
+          description: error.message || "Please try again.",
+          variant: "destructive",
+        });
+      },
+    });
+  };
 
   if (isError) {
     return (
@@ -169,7 +193,13 @@ export function TabOverview() {
   return (
     <div className="space-y-6">
       {/* Sales Metrics - Total Sales + Sales Trend */}
-      <SalesMetricsCard data={salesData} isLoading={salesLoading} />
+      <SalesMetricsCard
+        data={salesData}
+        isLoading={salesLoading}
+        onRecomputeRollups={handleRecomputeRollups}
+        isRecomputing={recomputeMutation.isPending}
+        canRecompute={isAdmin}
+      />
 
       {/* Category Demand */}
       <CategoryDemandSection />

--- a/apps/web/src/components/analytics/sales-metrics-card.tsx
+++ b/apps/web/src/components/analytics/sales-metrics-card.tsx
@@ -8,6 +8,8 @@ import {
   Bar,
   LineChart,
   Line,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   Tooltip,
@@ -15,8 +17,16 @@ import {
   Cell,
   ReferenceLine,
   CartesianGrid,
+  Legend,
 } from "recharts";
-import { TrendingUp, TrendingDown, BarChart3, DollarSign, CalendarDays } from "lucide-react";
+import { TrendingUp, TrendingDown, BarChart3, DollarSign, CalendarDays, Layers, RefreshCw, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip as TooltipUI,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { CalendarHeatmap } from "./calendar-heatmap";
 import { cn } from "@/lib/utils";
 import type { SalesSummary, MonthlySales, DailySales } from "@/types/api";
@@ -24,10 +34,13 @@ import type { SalesSummary, MonthlySales, DailySales } from "@/types/api";
 interface SalesMetricsCardProps {
   data: SalesSummary | undefined;
   isLoading?: boolean;
+  onRecomputeRollups?: () => void;
+  isRecomputing?: boolean;
+  canRecompute?: boolean;
 }
 
 type BarTimeFilter = "3M" | "6M" | "1Y" | "YTD";
-type ViewMode = "bar" | "line";
+type ViewMode = "bar" | "line" | "area";
 
 const BAR_FILTER_OPTIONS = ["3M", "6M", "1Y", "YTD"] as const;
 
@@ -81,6 +94,8 @@ interface ChartDataItem {
   month: string;
   label: string;
   revenue: number;
+  cost: number;
+  profit: number;
   units: number;
   isCurrent: boolean;
 }
@@ -117,6 +132,18 @@ function ViewToggle({ value, onChange }: ViewToggleProps) {
       >
         <TrendingUp className="h-4 w-4" />
       </button>
+      <button
+        onClick={() => onChange("area")}
+        className={cn(
+          "p-1 rounded transition-colors",
+          value === "area"
+            ? "bg-background dark:bg-muted shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        aria-label="Revenue/Profit area view"
+      >
+        <Layers className="h-4 w-4" />
+      </button>
     </div>
   );
 }
@@ -131,7 +158,9 @@ function CustomTooltip({
   if (!active || !payload || !payload.length) return null;
 
   const data = payload[0].payload;
-  const monthDate = new Date(data.month + "-01");
+  // Parse year-month manually to avoid UTC timezone issues
+  const [year, month] = data.month.split("-").map(Number);
+  const monthDate = new Date(year, month - 1, 1);
   const monthName = monthDate.toLocaleDateString("en-US", {
     month: "long",
     year: "numeric",
@@ -148,6 +177,34 @@ function CustomTooltip({
 
 interface LineChartDataItem extends ChartDataItem {
   previousRevenue?: number;
+}
+
+function AreaChartTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number; payload: ChartDataItem }>;
+}) {
+  if (!active || !payload || !payload.length) return null;
+
+  const data = payload[0].payload;
+  // Parse year-month manually to avoid UTC timezone issues
+  const [year, month] = data.month.split("-").map(Number);
+  const monthDate = new Date(year, month - 1, 1);
+  const monthName = monthDate.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="rounded-lg bg-zinc-900 px-3 py-2 text-sm text-white shadow-lg">
+      <p className="font-semibold mb-1">{monthName}</p>
+      <p className="text-emerald-400">Revenue: {formatCurrency(data.revenue)}</p>
+      <p className="text-red-400">Cost: {formatCurrency(data.cost)}</p>
+      <p className="text-blue-400">Profit: {formatCurrency(data.profit)}</p>
+    </div>
+  );
 }
 
 interface WeeklyChartDataItem {
@@ -332,7 +389,13 @@ function getPreviousPeriodWeekly(
     }));
 }
 
-export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
+export function SalesMetricsCard({
+  data,
+  isLoading,
+  onRecomputeRollups,
+  isRecomputing,
+  canRecompute,
+}: SalesMetricsCardProps) {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [barFilter, setBarFilter] = useState<BarTimeFilter>("1Y");
   const [viewMode, setViewMode] = useState<ViewMode>("bar");
@@ -380,7 +443,9 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
     const filtered = filterMonthlyData(data.monthlySales, barFilter);
 
     const formattedData: ChartDataItem[] = filtered.map((item) => {
-      const monthDate = new Date(item.month + "-01");
+      // Parse year-month manually to avoid UTC timezone issues
+      const [year, month] = item.month.split("-").map(Number);
+      const monthDate = new Date(year, month - 1, 1);
       const monthLabel = monthDate.toLocaleDateString("en-US", {
         month: "short",
       });
@@ -388,6 +453,8 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
         month: item.month,
         label: monthLabel,
         revenue: item.totalRevenue,
+        cost: item.totalCost ?? 0,
+        profit: item.totalProfit ?? 0,
         units: item.totalUnits,
         isCurrent: item.month === currentKey,
       };
@@ -555,6 +622,29 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
             Total Sales
           </CardTitle>
           <div className="flex items-center gap-2">
+            {canRecompute && (
+              <TooltipProvider delayDuration={50}>
+                <TooltipUI>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={onRecomputeRollups}
+                      disabled={isRecomputing || isLoading}
+                    >
+                      {isRecomputing ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    Recompute sales data
+                  </TooltipContent>
+                </TooltipUI>
+              </TooltipProvider>
+            )}
             <ViewToggle value={viewMode} onChange={setViewMode} />
             <TimeFilterTabs
               value={barFilter}
@@ -593,8 +683,8 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
 
           <div className="relative h-[220px] w-full">
             <div className="absolute inset-0">
-              <ResponsiveContainer width="100%" height="100%">
-                {viewMode === "bar" ? (
+              {viewMode === "bar" && (
+                <ResponsiveContainer width="100%" height="100%">
                   <BarChart
                     data={chartData}
                     margin={{ top: 10, right: 10, bottom: 0, left: -10 }}
@@ -643,7 +733,10 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
                       ))}
                     </Bar>
                   </BarChart>
-                ) : (
+                </ResponsiveContainer>
+              )}
+              {viewMode === "line" && (
+                <ResponsiveContainer width="100%" height="100%">
                   <LineChart
                     data={weeklyChartData}
                     margin={{ top: 10, right: 10, bottom: 0, left: -10 }}
@@ -685,8 +778,61 @@ export function SalesMetricsCard({ data, isLoading }: SalesMetricsCardProps) {
                     />
                     <Tooltip content={<LineChartTooltip />} />
                   </LineChart>
-                )}
-              </ResponsiveContainer>
+                </ResponsiveContainer>
+              )}
+              {viewMode === "area" && (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart
+                    data={chartData}
+                    margin={{ top: 10, right: 10, bottom: 0, left: -10 }}
+                  >
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      vertical={false}
+                      stroke="#e5e7eb"
+                    />
+                    <XAxis
+                      dataKey="label"
+                      axisLine={false}
+                      tickLine={false}
+                      tick={{ fontSize: 12, fill: "#9ca3af" }}
+                    />
+                    <YAxis
+                      axisLine={false}
+                      tickLine={false}
+                      tick={{ fontSize: 12, fill: "#9ca3af" }}
+                      tickFormatter={formatCompactCurrency}
+                      width={45}
+                    />
+                    <Tooltip content={<AreaChartTooltip />} />
+                    <Area
+                      type="monotone"
+                      dataKey="revenue"
+                      stroke="#10b981"
+                      fill="#10b981"
+                      fillOpacity={0.3}
+                      strokeWidth={2}
+                      name="Revenue"
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="cost"
+                      stroke="#ef4444"
+                      fill="#ef4444"
+                      fillOpacity={0.3}
+                      strokeWidth={2}
+                      name="Cost"
+                    />
+                    <Legend
+                      verticalAlign="top"
+                      height={36}
+                      formatter={(value) => (
+                        <span className="text-xs text-muted-foreground">{value}</span>
+                      )}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
             </div>
           </div>
         </CardContent>

--- a/apps/web/src/hooks/mutations/use-analytics-mutations.ts
+++ b/apps/web/src/hooks/mutations/use-analytics-mutations.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  recomputeRollups,
+  type RecomputeRollupsResponse,
+} from "@/lib/api/analytics";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useRecomputeRollupsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<RecomputeRollupsResponse, Error>({
+    mutationFn: recomputeRollups,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.analytics.all(),
+      });
+    },
+  });
+}

--- a/apps/web/src/lib/api/analytics.ts
+++ b/apps/web/src/lib/api/analytics.ts
@@ -1,4 +1,4 @@
-import { apiGet } from './client'
+import { apiGet, apiPost } from './client'
 import { PerformanceMetrics, SalesSummary } from '@/types/api'
 import {
   PredictionsData,
@@ -48,4 +48,23 @@ export async function getDemandLeaders(
     throw new Error(`Invalid period: ${period}. Must be one of: ${VALID_PERIODS.join(', ')}`);
   }
   return apiGet<DemandLeadersData>(`${BASE_PATH}/demand-leaders?period=${encodeURIComponent(period)}`)
+}
+
+export interface RecomputeRollupsResponse {
+  success: boolean;
+  rollupsRecomputed: number;
+  monthsBack: number;
+}
+
+/**
+ * Recomputes daily sales rollups from stock movement data.
+ * Use after MSRP updates to recalculate revenue/cost/profit values.
+ * Admin-only endpoint. This is a long-running operation (can take 1-2 minutes).
+ */
+export async function recomputeRollups(): Promise<RecomputeRollupsResponse> {
+  return apiPost<RecomputeRollupsResponse>(
+    `${BASE_PATH}/recompute-rollups?monthsBack=24`,
+    undefined,
+    { timeoutMs: 180000 } // 3 minute timeout for this long-running operation
+  )
 }

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -31,13 +31,14 @@ async function getAuthToken(): Promise<string | null> {
 interface FetchOptions extends RequestInit {
   skipAuth?: boolean;
   skipAuthRedirect?: boolean;
+  timeoutMs?: number;
 }
 
 export async function apiClient<T>(
   endpoint: string,
   options: FetchOptions = {}
 ): Promise<T> {
-  const { skipAuth = false, skipAuthRedirect = false, ...fetchOptions } = options;
+  const { skipAuth = false, skipAuthRedirect = false, timeoutMs, ...fetchOptions } = options;
 
   const headers = new Headers(fetchOptions.headers);
 
@@ -60,44 +61,59 @@ export async function apiClient<T>(
 
   const url = `${API_BASE_URL}${endpoint}`;
 
-  const response = await fetch(url, {
-    ...fetchOptions,
-    headers,
-  });
+  // Setup timeout with AbortController if specified
+  let timeoutId: NodeJS.Timeout | undefined;
+  let controller: AbortController | undefined;
+  if (timeoutMs) {
+    controller = new AbortController();
+    timeoutId = setTimeout(() => controller?.abort(), timeoutMs);
+  }
 
-  // Handle 401 Unauthorized - redirect to login (unless skipAuthRedirect is set)
-  if (response.status === 401) {
-    if (!skipAuthRedirect && typeof window !== "undefined") {
-      window.location.href = "/login";
-    }
-    throw new ApiClientError({
-      timestamp: new Date().toISOString(),
-      status: 401,
-      error: "Unauthorized",
-      message: "Authentication required",
+  try {
+    const response = await fetch(url, {
+      ...fetchOptions,
+      headers,
+      signal: controller?.signal,
     });
+
+    // Handle 401 Unauthorized - redirect to login (unless skipAuthRedirect is set)
+    if (response.status === 401) {
+      if (!skipAuthRedirect && typeof window !== "undefined") {
+        window.location.href = "/login";
+      }
+      throw new ApiClientError({
+        timestamp: new Date().toISOString(),
+        status: 401,
+        error: "Unauthorized",
+        message: "Authentication required",
+      });
+    }
+
+    // Handle empty response (204 No Content, 201 Created with no body, etc.)
+    const contentLength = response.headers.get("content-length");
+    const contentType = response.headers.get("content-type");
+    const isEmptyResponse =
+      response.status === 204 ||
+      contentLength === "0" ||
+      (response.status === 201 && !contentType?.includes("application/json"));
+
+    if (isEmptyResponse) {
+      return undefined as T;
+    }
+
+    const data = await response.json();
+
+    // Handle error responses
+    if (!response.ok) {
+      throw new ApiClientError(data as ApiError);
+    }
+
+    return data as T;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
-
-  // Handle empty response (204 No Content, 201 Created with no body, etc.)
-  const contentLength = response.headers.get("content-length");
-  const contentType = response.headers.get("content-type");
-  const isEmptyResponse =
-    response.status === 204 ||
-    contentLength === "0" ||
-    (response.status === 201 && !contentType?.includes("application/json"));
-
-  if (isEmptyResponse) {
-    return undefined as T;
-  }
-
-  const data = await response.json();
-
-  // Handle error responses
-  if (!response.ok) {
-    throw new ApiClientError(data as ApiError);
-  }
-
-  return data as T;
 }
 
 // HTTP method helpers

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -568,6 +568,8 @@ export interface PerformanceMetrics {
 export interface MonthlySales {
   month: string;
   totalRevenue: number;
+  totalCost: number;
+  totalProfit: number;
   totalUnits: number;
 }
 
@@ -575,12 +577,16 @@ export interface DailySales {
   date: string;
   totalUnits: number;
   totalRevenue: number;
+  totalCost: number;
+  totalProfit: number;
 }
 
 export interface SalesSummary {
   monthlySales: MonthlySales[];
   dailySales: DailySales[];
   totalRevenue: number;
+  totalCost: number;
+  totalProfit: number;
   totalUnits: number;
   periodStart: string;
   periodEnd: string;

--- a/scripts/update_msrp.py
+++ b/scripts/update_msrp.py
@@ -130,12 +130,12 @@ def load_csv(csv_path: Path) -> dict[str, CsvProduct]:
 
 
 def load_db_products(conn) -> list[DbProduct]:
-    """Load all products from database."""
+    """Load all parent products from database (excludes child products)."""
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute("""
             SELECT id, name, sku, msrp
             FROM products
-            WHERE is_active = true
+            WHERE parent_id IS NULL
             ORDER BY name
         """)
         return [

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/AnalyticsController.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/AnalyticsController.java
@@ -12,6 +12,7 @@ import com.mirai.inventoryservice.dtos.responses.InsightsDTO;
 import com.mirai.inventoryservice.dtos.responses.PerformanceMetricsDTO;
 import com.mirai.inventoryservice.dtos.responses.SalesSummaryDTO;
 import com.mirai.inventoryservice.models.enums.StockMovementReason;
+import com.mirai.inventoryservice.services.AnalyticsSeedService;
 import com.mirai.inventoryservice.services.AnalyticsService;
 import com.mirai.inventoryservice.services.ProductReportBundleService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Max;
@@ -31,6 +33,7 @@ import jakarta.validation.constraints.Min;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -42,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;
+    private final AnalyticsSeedService analyticsSeedService;
     private final ProductReportBundleService productReportBundleService;
 
     @GetMapping("/inventory-by-category")
@@ -57,6 +61,23 @@ public class AnalyticsController {
     @GetMapping("/sales-summary")
     public SalesSummaryDTO getSalesSummary() {
         return analyticsService.getSalesSummary();
+    }
+
+    /**
+     * Recomputes daily sales rollups from stock movement data.
+     * Use after MSRP updates to recalculate revenue/cost/profit values.
+     * @param monthsBack Number of months to recompute (default 24, max 36)
+     */
+    @PostMapping("/recompute-rollups")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, Object>> recomputeRollups(
+            @RequestParam(defaultValue = "24") @Min(1) @Max(36) int monthsBack) {
+        int count = analyticsSeedService.recomputeAllRollups(monthsBack);
+        return ResponseEntity.ok(Map.of(
+            "success", true,
+            "rollupsRecomputed", count,
+            "monthsBack", monthsBack
+        ));
     }
 
     /**

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/DailySalesDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/DailySalesDTO.java
@@ -5,5 +5,7 @@ import java.math.BigDecimal;
 public record DailySalesDTO(
     String date,
     Integer totalUnits,
-    BigDecimal totalRevenue
+    BigDecimal totalRevenue,
+    BigDecimal totalCost,
+    BigDecimal totalProfit
 ) {}

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/MonthlySalesDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/MonthlySalesDTO.java
@@ -5,5 +5,7 @@ import java.math.BigDecimal;
 public record MonthlySalesDTO(
     String month,
     BigDecimal totalRevenue,
+    BigDecimal totalCost,
+    BigDecimal totalProfit,
     Integer totalUnits
 ) {}

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/SalesSummaryDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/SalesSummaryDTO.java
@@ -7,6 +7,8 @@ public record SalesSummaryDTO(
     List<MonthlySalesDTO> monthlySales,
     List<DailySalesDTO> dailySales,
     BigDecimal totalRevenue,
+    BigDecimal totalCost,
+    BigDecimal totalProfit,
     Integer totalUnits,
     String periodStart,
     String periodEnd

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/analytics/DailySalesRollup.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/analytics/DailySalesRollup.java
@@ -55,6 +55,20 @@ public class DailySalesRollup {
     @Builder.Default
     private BigDecimal revenue = BigDecimal.ZERO;
 
+    /**
+     * Total cost of goods sold = unit_cost x units_sold.
+     */
+    @Column(name = "cost", precision = 12, scale = 2, nullable = false)
+    @Builder.Default
+    private BigDecimal cost = BigDecimal.ZERO;
+
+    /**
+     * Gross profit = revenue - cost = (msrp - unit_cost) x units_sold.
+     */
+    @Column(name = "profit", precision = 12, scale = 2, nullable = false)
+    @Builder.Default
+    private BigDecimal profit = BigDecimal.ZERO;
+
     @Column(name = "restock_units", nullable = false)
     @Builder.Default
     private Integer restockUnits = 0;

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/CategoryDemandRollupRepository.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/CategoryDemandRollupRepository.java
@@ -81,4 +81,11 @@ public interface CategoryDemandRollupRepository extends JpaRepository<CategoryDe
      * Check if rollup exists for category on date.
      */
     boolean existsByCategoryIdAndRollupDate(UUID categoryId, LocalDate rollupDate);
+
+    /**
+     * Find all category IDs that have rollups for a given date.
+     * Used to batch-check existence instead of N individual queries.
+     */
+    @Query("SELECT cr.categoryId FROM CategoryDemandRollup cr WHERE cr.rollupDate = :date")
+    List<UUID> findCategoryIdsByRollupDate(@Param("date") LocalDate date);
 }

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/DailySalesRollupRepository.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/DailySalesRollupRepository.java
@@ -63,9 +63,12 @@ public interface DailySalesRollupRepository extends JpaRepository<DailySalesRoll
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
 
-    // Total revenue and units for a date range
+    // Total revenue, cost, profit and units for a date range
     @Query("""
-        SELECT COALESCE(SUM(r.unitsSold), 0), COALESCE(SUM(r.revenue), 0)
+        SELECT COALESCE(SUM(r.unitsSold), 0),
+               COALESCE(SUM(r.revenue), 0),
+               COALESCE(SUM(r.cost), 0),
+               COALESCE(SUM(r.profit), 0)
         FROM DailySalesRollup r
         WHERE r.rollupDate >= :startDate AND r.rollupDate <= :endDate
         """)
@@ -79,11 +82,13 @@ public interface DailySalesRollupRepository extends JpaRepository<DailySalesRoll
                EXTRACT(MONTH FROM r.rollup_date) as month,
                SUM(r.units_sold) as total_units,
                SUM(r.revenue) as total_revenue,
+               SUM(r.cost) as total_cost,
+               SUM(r.profit) as total_profit,
                COUNT(DISTINCT r.item_id) as unique_items
         FROM analytics_daily_rollup r
         WHERE r.rollup_date >= :startDate
         GROUP BY EXTRACT(YEAR FROM r.rollup_date), EXTRACT(MONTH FROM r.rollup_date)
-        ORDER BY year DESC, month DESC
+        ORDER BY year ASC, month ASC
         """, nativeQuery = true)
     List<Object[]> aggregateByMonth(@Param("startDate") LocalDate startDate);
 
@@ -91,6 +96,11 @@ public interface DailySalesRollupRepository extends JpaRepository<DailySalesRoll
     @Modifying
     @Query("DELETE FROM DailySalesRollup r WHERE r.rollupDate < :cutoffDate")
     int deleteOlderThan(@Param("cutoffDate") LocalDate cutoffDate);
+
+    // Bulk delete rollups in date range (much faster than loading + deleteAll)
+    @Modifying
+    @Query("DELETE FROM DailySalesRollup r WHERE r.rollupDate >= :startDate AND r.rollupDate <= :endDate")
+    int deleteByRollupDateBetween(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     // Find rollups for seeded data cleanup
     @Query("""

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/ForecastSnapshotRepository.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/ForecastSnapshotRepository.java
@@ -72,4 +72,11 @@ public interface ForecastSnapshotRepository extends JpaRepository<ForecastDailyS
      * Check if snapshot exists for item on date.
      */
     boolean existsByItemIdAndSnapshotDate(UUID itemId, LocalDate snapshotDate);
+
+    /**
+     * Find all item IDs that have snapshots for a given date.
+     * Used to batch-check existence instead of N individual queries.
+     */
+    @Query("SELECT fs.itemId FROM ForecastDailySnapshot fs WHERE fs.snapshotDate = :date")
+    List<UUID> findItemIdsBySnapshotDate(@Param("date") LocalDate date);
 }

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/ProductRepository.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/ProductRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +23,13 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
 
     @Query("SELECT p FROM Product p LEFT JOIN FETCH p.category c LEFT JOIN FETCH c.parent LEFT JOIN FETCH p.parent WHERE p.isActive = true")
     List<Product> findByIsActiveTrueWithCategories();
+
+    /**
+     * Find products by IDs with categories eagerly loaded.
+     * Used to fetch only products with matching forecast predictions instead of all products.
+     */
+    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.category c LEFT JOIN FETCH c.parent LEFT JOIN FETCH p.parent WHERE p.id IN :ids")
+    List<Product> findByIdInWithCategories(@Param("ids") Collection<UUID> ids);
 
     @Query("SELECT p FROM Product p LEFT JOIN FETCH p.category c LEFT JOIN FETCH c.parent LEFT JOIN FETCH p.parent WHERE p.category.id = :categoryId")
     List<Product> findByCategoryIdWithCategories(@Param("categoryId") UUID categoryId);

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/StockMovementRepository.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/repositories/StockMovementRepository.java
@@ -89,5 +89,30 @@ public interface StockMovementRepository extends JpaRepository<StockMovement, Lo
             @Param("to") OffsetDateTime to,
             @Param("reasons") List<StockMovementReason> reasons,
             org.springframework.data.domain.Pageable pageable);
+
+    /**
+     * Aggregate sales movements by item and date for rollup computation.
+     * Does the aggregation in SQL to avoid loading all entities into memory.
+     * Returns: item_id, rollup_date, units_sold, revenue, cost, profit, movement_count
+     */
+    @Query(value = """
+        SELECT
+            sm.item_id,
+            DATE(sm.at AT TIME ZONE 'UTC') as rollup_date,
+            SUM(ABS(sm.quantity_change)) as units_sold,
+            SUM(ABS(sm.quantity_change) * COALESCE(p.msrp, 0)) as revenue,
+            SUM(ABS(sm.quantity_change) * COALESCE(p.unit_cost, 0)) as cost,
+            SUM(ABS(sm.quantity_change) * (COALESCE(p.msrp, 0) - COALESCE(p.unit_cost, 0))) as profit,
+            COUNT(*) as movement_count
+        FROM stock_movements sm
+        JOIN products p ON sm.item_id = p.id
+        WHERE sm.reason = 'SALE'
+          AND sm.at >= :startDate
+          AND sm.at < :endDate
+        GROUP BY sm.item_id, DATE(sm.at AT TIME ZONE 'UTC')
+        """, nativeQuery = true)
+    List<Object[]> aggregateSalesByItemAndDate(
+            @Param("startDate") OffsetDateTime startDate,
+            @Param("endDate") OffsetDateTime endDate);
 }
 

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsSeedService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsSeedService.java
@@ -19,8 +19,10 @@ import com.mirai.inventoryservice.repositories.InventoryTotalsRepository;
 import com.mirai.inventoryservice.repositories.MonthlyPerformanceRollupRepository;
 import com.mirai.inventoryservice.repositories.ProductRepository;
 import com.mirai.inventoryservice.repositories.StockMovementRepository;
+import com.mirai.inventoryservice.config.CacheConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,6 +56,7 @@ public class AnalyticsSeedService {
     private final ForecastSnapshotRepository forecastSnapshotRepository;
     private final CategoryDemandRollupRepository categoryDemandRollupRepository;
     private final InventoryTotalsRepository inventoryTotalsRepository;
+    private final CacheManager cacheManager;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Random random = new Random();
@@ -69,13 +72,16 @@ public class AnalyticsSeedService {
     public Map<String, Object> seedAllAnalytics(int monthsBack) {
         log.info("Starting analytics seed for {} months back", monthsBack);
 
-        // Ensure products have proper defaults before seeding forecasts
-        int productsUpdated = updateProductDefaults();
+        // Load products once and pass to sub-methods to avoid multiple findAll() calls
+        List<Product> products = productRepository.findAll();
 
-        int salesCreated = seedDowPatternSales(monthsBack);
-        int dailyRollups = seedDailyRollups(monthsBack);
+        // Ensure products have proper defaults before seeding forecasts
+        int productsUpdated = updateProductDefaults(products);
+
+        int salesCreated = seedDowPatternSales(monthsBack, products);
+        int dailyRollups = seedDailyRollups(monthsBack, products);
         int monthlyRollups = seedMonthlyRollups(monthsBack);
-        int forecastsCreated = seedForecastPredictions();
+        int forecastsCreated = seedForecastPredictions(products);
 
         return Map.of(
             "success", true,
@@ -97,7 +103,10 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedForecastPredictions() {
-        List<Product> products = productRepository.findAll();
+        return seedForecastPredictions(productRepository.findAll());
+    }
+
+    private int seedForecastPredictions(List<Product> products) {
         if (products.isEmpty()) {
             log.warn("No products found for forecast seeding");
             return 0;
@@ -194,10 +203,19 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedDowPatternSales(int monthsBack) {
-        List<Product> products = productRepository.findAll();
+        return seedDowPatternSales(monthsBack, productRepository.findAll());
+    }
+
+    private int seedDowPatternSales(int monthsBack, List<Product> products) {
         if (products.isEmpty()) {
             log.warn("No products found for DOW pattern seeding");
             return 0;
+        }
+
+        // Build index map once to avoid N+1 in getBaseRateForProduct
+        Map<UUID, Integer> productIndexMap = new HashMap<>();
+        for (int i = 0; i < products.size(); i++) {
+            productIndexMap.put(products.get(i).getId(), i);
         }
 
         LocalDate today = LocalDate.now();
@@ -206,7 +224,7 @@ public class AnalyticsSeedService {
 
         for (Product product : products) {
             // Vary base sales rate per product (simulating top/steady/slow sellers)
-            double baseDailyRate = getBaseRateForProduct(product, products.size());
+            double baseDailyRate = getBaseRateForProduct(product, products.size(), productIndexMap);
 
             LocalDate currentDate = startDate;
             while (!currentDate.isAfter(today)) {
@@ -250,7 +268,10 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedDailyRollups(int monthsBack) {
-        List<Product> products = productRepository.findAll();
+        return seedDailyRollups(monthsBack, productRepository.findAll());
+    }
+
+    private int seedDailyRollups(int monthsBack, List<Product> products) {
         if (products.isEmpty()) {
             return 0;
         }
@@ -277,19 +298,29 @@ public class AnalyticsSeedService {
                     .rollupDate(date)
                     .unitsSold(0)
                     .revenue(BigDecimal.ZERO)
+                    .cost(BigDecimal.ZERO)
+                    .profit(BigDecimal.ZERO)
                     .restockUnits(0)
                     .damageUnits(0)
                     .movementCount(0)
                     .build()
             );
 
+            // Calculate revenue (MSRP-based), cost, and profit
+            Product item = movement.getItem();
             int units = Math.abs(movement.getQuantityChange());
-            BigDecimal revenue = movement.getItem().getUnitCost() != null
-                ? movement.getItem().getUnitCost().multiply(BigDecimal.valueOf(units))
-                : BigDecimal.ZERO;
+            BigDecimal unitQty = BigDecimal.valueOf(units);
+            BigDecimal msrp = item.getMsrp() != null ? item.getMsrp() : BigDecimal.ZERO;
+            BigDecimal unitCost = item.getUnitCost() != null ? item.getUnitCost() : BigDecimal.ZERO;
+
+            BigDecimal revenue = msrp.multiply(unitQty);
+            BigDecimal cost = unitCost.multiply(unitQty);
+            BigDecimal profit = revenue.subtract(cost);
 
             rollup.setUnitsSold(rollup.getUnitsSold() + units);
             rollup.setRevenue(rollup.getRevenue().add(revenue));
+            rollup.setCost(rollup.getCost().add(cost));
+            rollup.setProfit(rollup.getProfit().add(profit));
             rollup.setMovementCount(rollup.getMovementCount() + 1);
         }
 
@@ -316,6 +347,85 @@ public class AnalyticsSeedService {
 
         dailySalesRollupRepository.saveAll(rollups);
         log.info("Seeded {} daily rollups", rollups.size());
+        return rollups.size();
+    }
+
+    /**
+     * Recompute all daily rollups from existing stock movements.
+     * Deletes existing rollups and recreates them with updated MSRP-based revenue calculation.
+     * Clears the sales summary cache after completion.
+     *
+     * OPTIMIZED: Uses bulk delete and SQL aggregation instead of loading entities into memory.
+     *
+     * @param monthsBack Number of months to recompute
+     * @return Number of rollups created
+     */
+    @Transactional
+    public int recomputeAllRollups(int monthsBack) {
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = today.minusMonths(monthsBack);
+
+        // Bulk delete existing rollups (single DELETE statement, not entity-by-entity)
+        int deleted = dailySalesRollupRepository.deleteByRollupDateBetween(startDate, today);
+        log.info("Deleted {} existing rollups for recomputation", deleted);
+
+        // Recompute from stock_movements using SQL aggregation
+        int count = recomputeRollupsOptimized(startDate, today);
+
+        // Clear sales summary cache
+        var cache = cacheManager.getCache(CacheConfig.SALES_SUMMARY_CACHE);
+        if (cache != null) {
+            cache.clear();
+            log.info("Cleared sales summary cache");
+        }
+
+        log.info("Recomputed {} daily rollups", count);
+        return count;
+    }
+
+    /**
+     * Optimized rollup computation using SQL aggregation.
+     * Aggregates data in the database instead of loading all movements into memory.
+     */
+    private int recomputeRollupsOptimized(LocalDate startDate, LocalDate endDate) {
+        OffsetDateTime startDateTime = startDate.atStartOfDay().atOffset(ZoneOffset.UTC);
+        OffsetDateTime endDateTime = endDate.plusDays(1).atStartOfDay().atOffset(ZoneOffset.UTC);
+
+        // Use native SQL aggregation - much faster than loading all entities
+        List<Object[]> aggregatedData = stockMovementRepository.aggregateSalesByItemAndDate(
+            startDateTime, endDateTime);
+
+        if (aggregatedData.isEmpty()) {
+            log.info("No sales movements found in date range");
+            return 0;
+        }
+
+        List<DailySalesRollup> rollups = new ArrayList<>();
+        for (Object[] row : aggregatedData) {
+            UUID itemId = (UUID) row[0];
+            LocalDate rollupDate = ((java.sql.Date) row[1]).toLocalDate();
+            int unitsSold = ((Number) row[2]).intValue();
+            BigDecimal revenue = row[3] != null ? new BigDecimal(row[3].toString()) : BigDecimal.ZERO;
+            BigDecimal cost = row[4] != null ? new BigDecimal(row[4].toString()) : BigDecimal.ZERO;
+            BigDecimal profit = row[5] != null ? new BigDecimal(row[5].toString()) : BigDecimal.ZERO;
+            int movementCount = ((Number) row[6]).intValue();
+
+            rollups.add(DailySalesRollup.builder()
+                .itemId(itemId)
+                .rollupDate(rollupDate)
+                .unitsSold(unitsSold)
+                .revenue(revenue)
+                .cost(cost)
+                .profit(profit)
+                .restockUnits(0)
+                .damageUnits(0)
+                .movementCount(movementCount)
+                .build());
+        }
+
+        // Batch save all rollups
+        dailySalesRollupRepository.saveAll(rollups);
+        log.info("Created {} daily rollups from SQL aggregation", rollups.size());
         return rollups.size();
     }
 
@@ -448,7 +558,10 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int updateProductDefaults() {
-        List<Product> products = productRepository.findAll();
+        return updateProductDefaults(productRepository.findAll());
+    }
+
+    private int updateProductDefaults(List<Product> products) {
         int updated = 0;
 
         for (Product product : products) {
@@ -512,6 +625,8 @@ public class AnalyticsSeedService {
                     .rollupDate(date)
                     .unitsSold(0)
                     .revenue(BigDecimal.ZERO)
+                    .cost(BigDecimal.ZERO)
+                    .profit(BigDecimal.ZERO)
                     .restockUnits(0)
                     .damageUnits(0)
                     .movementCount(0)
@@ -519,13 +634,21 @@ public class AnalyticsSeedService {
             );
 
             if (existing == null) {
+                // Calculate revenue (MSRP-based), cost, and profit
+                Product item = movement.getItem();
                 int units = Math.abs(movement.getQuantityChange());
-                BigDecimal revenue = movement.getItem().getUnitCost() != null
-                    ? movement.getItem().getUnitCost().multiply(BigDecimal.valueOf(units))
-                    : BigDecimal.ZERO;
+                BigDecimal unitQty = BigDecimal.valueOf(units);
+                BigDecimal msrp = item.getMsrp() != null ? item.getMsrp() : BigDecimal.ZERO;
+                BigDecimal unitCost = item.getUnitCost() != null ? item.getUnitCost() : BigDecimal.ZERO;
+
+                BigDecimal revenue = msrp.multiply(unitQty);
+                BigDecimal cost = unitCost.multiply(unitQty);
+                BigDecimal profit = revenue.subtract(cost);
 
                 rollup.setUnitsSold(rollup.getUnitsSold() + units);
                 rollup.setRevenue(rollup.getRevenue().add(revenue));
+                rollup.setCost(rollup.getCost().add(cost));
+                rollup.setProfit(rollup.getProfit().add(profit));
                 rollup.setMovementCount(rollup.getMovementCount() + 1);
             }
         }
@@ -533,9 +656,9 @@ public class AnalyticsSeedService {
         dailySalesRollupRepository.saveAll(rollupMap.values());
     }
 
-    private double getBaseRateForProduct(Product product, int totalProducts) {
+    private double getBaseRateForProduct(Product product, int totalProducts, Map<UUID, Integer> productIndexMap) {
         // Assign products to tiers based on their position
-        int index = productRepository.findAll().indexOf(product);
+        int index = productIndexMap.getOrDefault(product.getId(), 0);
         double position = (double) index / totalProducts;
 
         if (position < 0.2) {
@@ -569,11 +692,15 @@ public class AnalyticsSeedService {
             return 0;
         }
 
+        // Batch fetch existing snapshots for today to avoid N+1 EXISTS queries
+        java.util.Set<UUID> existingItemIds = new java.util.HashSet<>(
+            forecastSnapshotRepository.findItemIdsBySnapshotDate(today));
+
         List<ForecastDailySnapshot> snapshots = new ArrayList<>();
 
         for (ForecastPrediction prediction : latestPredictions) {
             // Skip if already snapshotted today
-            if (forecastSnapshotRepository.existsByItemIdAndSnapshotDate(prediction.getItemId(), today)) {
+            if (existingItemIds.contains(prediction.getItemId())) {
                 continue;
             }
 
@@ -641,6 +768,10 @@ public class AnalyticsSeedService {
             }
         }
 
+        // Batch fetch existing rollups for today to avoid N+1 EXISTS queries
+        java.util.Set<UUID> existingCategoryIds = new java.util.HashSet<>(
+            categoryDemandRollupRepository.findCategoryIdsByRollupDate(today));
+
         List<CategoryDemandRollup> rollups = new ArrayList<>();
 
         for (Map.Entry<UUID, List<Product>> entry : productsByCategory.entrySet()) {
@@ -648,7 +779,7 @@ public class AnalyticsSeedService {
             List<Product> categoryProducts = entry.getValue();
 
             // Skip if already rolled up today
-            if (categoryDemandRollupRepository.existsByCategoryIdAndRollupDate(categoryId, today)) {
+            if (existingCategoryIds.contains(categoryId)) {
                 continue;
             }
 

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsService.java
@@ -340,7 +340,9 @@ public class AnalyticsService {
         List<DailySalesRollup> dailyRollups = dailySalesRollupRepository
             .findByRollupDateBetweenOrderByRollupDateAsc(periodStart, today);
         List<Object[]> totalsList = dailySalesRollupRepository.getTotalsForPeriod(periodStart, today);
-        Object[] totals = totalsList.isEmpty() ? new Object[]{0, BigDecimal.ZERO} : totalsList.get(0);
+        Object[] totals = totalsList.isEmpty()
+            ? new Object[]{0, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO}
+            : totalsList.get(0);
 
         List<MonthlySalesDTO> monthlySales = monthlyRows.stream()
             .map(row -> {
@@ -348,20 +350,24 @@ public class AnalyticsService {
                 int month = ((Number) row[1]).intValue();
                 String monthKey = String.format("%d-%02d", year, month);
                 int units = ((Number) row[2]).intValue();
-                BigDecimal revenue = row[3] instanceof BigDecimal bd
-                    ? bd.setScale(2, RoundingMode.HALF_UP)
-                    : BigDecimal.valueOf(((Number) row[3]).doubleValue()).setScale(2, RoundingMode.HALF_UP);
-                return new MonthlySalesDTO(monthKey, revenue, units);
+                BigDecimal revenue = toBigDecimal(row[3]);
+                BigDecimal cost = toBigDecimal(row[4]);
+                BigDecimal profit = toBigDecimal(row[5]);
+                return new MonthlySalesDTO(monthKey, revenue, cost, profit, units);
             })
             .toList();
 
         // Aggregate daily rollups by date (multiple items per day -> one row per day)
         Map<String, Integer> dailyUnits = new TreeMap<>();
         Map<String, BigDecimal> dailyRevenue = new TreeMap<>();
+        Map<String, BigDecimal> dailyCost = new TreeMap<>();
+        Map<String, BigDecimal> dailyProfit = new TreeMap<>();
         for (DailySalesRollup rollup : dailyRollups) {
             String dateKey = rollup.getRollupDate().format(dateFormatter);
             dailyUnits.merge(dateKey, rollup.getUnitsSold(), Integer::sum);
             dailyRevenue.merge(dateKey, rollup.getRevenue(), BigDecimal::add);
+            dailyCost.merge(dateKey, rollup.getCost(), BigDecimal::add);
+            dailyProfit.merge(dateKey, rollup.getProfit(), BigDecimal::add);
         }
 
         List<DailySalesDTO> dailySales = dailyUnits.entrySet().stream()
@@ -369,25 +375,39 @@ public class AnalyticsService {
                 entry.getKey(),
                 entry.getValue(),
                 dailyRevenue.getOrDefault(entry.getKey(), BigDecimal.ZERO)
+                    .setScale(2, RoundingMode.HALF_UP),
+                dailyCost.getOrDefault(entry.getKey(), BigDecimal.ZERO)
+                    .setScale(2, RoundingMode.HALF_UP),
+                dailyProfit.getOrDefault(entry.getKey(), BigDecimal.ZERO)
                     .setScale(2, RoundingMode.HALF_UP)
             ))
             .toList();
 
         int totalUnits = totals[0] != null ? ((Number) totals[0]).intValue() : 0;
-        BigDecimal totalRevenue = totals[1] != null
-            ? (totals[1] instanceof BigDecimal bd
-                ? bd.setScale(2, RoundingMode.HALF_UP)
-                : BigDecimal.valueOf(((Number) totals[1]).doubleValue()).setScale(2, RoundingMode.HALF_UP))
-            : BigDecimal.ZERO;
+        BigDecimal totalRevenue = toBigDecimal(totals[1]);
+        BigDecimal totalCost = toBigDecimal(totals[2]);
+        BigDecimal totalProfit = toBigDecimal(totals[3]);
 
         return new SalesSummaryDTO(
             monthlySales,
             dailySales,
             totalRevenue,
+            totalCost,
+            totalProfit,
             totalUnits,
             periodStart.format(dateFormatter),
             today.format(dateFormatter)
         );
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) {
+            return BigDecimal.ZERO;
+        }
+        if (value instanceof BigDecimal bd) {
+            return bd.setScale(2, RoundingMode.HALF_UP);
+        }
+        return BigDecimal.valueOf(((Number) value).doubleValue()).setScale(2, RoundingMode.HALF_UP);
     }
 
     /**
@@ -399,8 +419,15 @@ public class AnalyticsService {
     public ActionCenterDTO getActionCenter() {
         List<ForecastPrediction> latestPredictions = forecastPredictionRepository.findAllLatest();
         Map<UUID, Integer> stockMap = inventoryTotalsRepository.findAllStockTotalsMap();
-        List<Product> allProducts = productRepository.findAllWithCategories();
-        Map<UUID, Product> productMap = allProducts.stream()
+
+        // Fetch only products with forecast predictions instead of all products
+        Set<UUID> itemIds = latestPredictions.stream()
+            .map(ForecastPrediction::getItemId)
+            .collect(Collectors.toSet());
+        List<Product> products = itemIds.isEmpty()
+            ? List.of()
+            : productRepository.findByIdInWithCategories(itemIds);
+        Map<UUID, Product> productMap = products.stream()
             .collect(Collectors.toMap(Product::getId, Function.identity()));
 
         List<ActionItem> actionItems = new ArrayList<>();
@@ -794,17 +821,23 @@ public class AnalyticsService {
             }
         }
 
-        List<Product> products = productRepository.findAllWithCategories();
-        Map<UUID, Product> productMap = products.stream()
-            .collect(Collectors.toMap(Product::getId, Function.identity()));
-        List<Category> categories = categoryRepository.findAll();
-        Map<UUID, Integer> stockMap = inventoryTotalsRepository.findAllStockTotalsMap();
-
         List<ForecastPrediction> latestPredictions = forecastPredictionRepository.findAllLatest();
         Map<UUID, ForecastFeatures> featuresMap = new HashMap<>();
         for (ForecastPrediction fp : latestPredictions) {
             featuresMap.put(fp.getItemId(), extractFeatures(fp));
         }
+
+        // Fetch only products with forecast predictions instead of all products
+        Set<UUID> itemIds = latestPredictions.stream()
+            .map(ForecastPrediction::getItemId)
+            .collect(Collectors.toSet());
+        List<Product> products = itemIds.isEmpty()
+            ? List.of()
+            : productRepository.findByIdInWithCategories(itemIds);
+        Map<UUID, Product> productMap = products.stream()
+            .collect(Collectors.toMap(Product::getId, Function.identity()));
+        List<Category> categories = categoryRepository.findAll();
+        Map<UUID, Integer> stockMap = inventoryTotalsRepository.findAllStockTotalsMap();
 
         // Fetch rollups for both current and previous periods in a single query
         List<DailySalesRollup> allRollups = dailySalesRollupRepository
@@ -947,6 +980,14 @@ public class AnalyticsService {
             unitsByCategory.merge(categoryId, unitsByItem.getOrDefault(itemId, 0), Integer::sum);
         }
 
+        // Pre-compute item counts by category to avoid O(n*m) stream filtering
+        Map<UUID, Integer> itemCountByCategory = new HashMap<>();
+        for (Product product : products) {
+            if (product.getCategory() != null) {
+                itemCountByCategory.merge(product.getCategory().getId(), 1, Integer::sum);
+            }
+        }
+
         final BigDecimal finalTotalDemandVelocity2 = totalDemandVelocity;
         List<CategoryRanking> categoryRankings = categories.stream()
             .filter(cat -> demandVelocityByCategory.containsKey(cat.getId()))
@@ -957,9 +998,7 @@ public class AnalyticsService {
                 UUID catId = cat.getId();
                 BigDecimal catDemandVelocity = demandVelocityByCategory.getOrDefault(catId, BigDecimal.ZERO);
                 int catUnits = unitsByCategory.getOrDefault(catId, 0);
-                int totalItems = (int) products.stream()
-                    .filter(p -> p.getCategory() != null && p.getCategory().getId().equals(catId))
-                    .count();
+                int totalItems = itemCountByCategory.getOrDefault(catId, 0);
                 BigDecimal percentOfTotal = finalTotalDemandVelocity2.compareTo(BigDecimal.ZERO) > 0
                     ? catDemandVelocity.multiply(BigDecimal.valueOf(100))
                         .divide(finalTotalDemandVelocity2, 1, RoundingMode.HALF_UP)

--- a/services/inventory-service/src/main/resources/db/migration/V23__add_profit_cost_to_rollups.sql
+++ b/services/inventory-service/src/main/resources/db/migration/V23__add_profit_cost_to_rollups.sql
@@ -1,0 +1,11 @@
+-- Add cost and profit columns to daily rollups for revenue/cost/profit tracking
+-- Revenue = msrp x units_sold (retail price)
+-- Cost = unit_cost x units_sold (cost of goods)
+-- Profit = revenue - cost (gross margin)
+
+ALTER TABLE analytics_daily_rollup
+ADD COLUMN cost DECIMAL(12, 2) NOT NULL DEFAULT 0,
+ADD COLUMN profit DECIMAL(12, 2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN analytics_daily_rollup.cost IS 'Total cost = unit_cost x units_sold';
+COMMENT ON COLUMN analytics_daily_rollup.profit IS 'Gross profit = revenue - cost = (msrp - unit_cost) x units_sold';

--- a/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/AnalyticsServiceTest.java
+++ b/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/AnalyticsServiceTest.java
@@ -161,14 +161,14 @@ class AnalyticsServiceTest {
             Category category = buildCategory(UUID.randomUUID(), "Plush");
             Product product = buildProduct(productId, "Test Plush", "PLU-001", category);
 
-            when(productRepository.findAllWithCategories())
+            when(forecastPredictionRepository.findAllLatest())
+                    .thenReturn(List.of(buildPrediction(productId)));
+            when(productRepository.findByIdInWithCategories(any()))
                     .thenReturn(List.of(product));
             when(categoryRepository.findAll())
                     .thenReturn(List.of(category));
             when(inventoryTotalsRepository.findAllStockTotalsMap())
                     .thenReturn(Map.of(productId, 30));
-            when(forecastPredictionRepository.findAllLatest())
-                    .thenReturn(List.of(buildPrediction(productId)));
             when(dailySalesRollupRepository.findByRollupDateBetweenOrderByRollupDateAsc(any(), any()))
                     .thenReturn(Collections.emptyList());
 
@@ -181,10 +181,10 @@ class AnalyticsServiceTest {
         @Test
         @DisplayName("uses different date ranges for different periods")
         void usesDifferentDateRangesForDifferentPeriods() {
-            when(productRepository.findAllWithCategories()).thenReturn(Collections.emptyList());
+            when(forecastPredictionRepository.findAllLatest()).thenReturn(Collections.emptyList());
+            // When no predictions, findByIdInWithCategories won't be called (empty ID set)
             when(categoryRepository.findAll()).thenReturn(Collections.emptyList());
             when(inventoryTotalsRepository.findAllStockTotalsMap()).thenReturn(Collections.emptyMap());
-            when(forecastPredictionRepository.findAllLatest()).thenReturn(Collections.emptyList());
             when(dailySalesRollupRepository.findByRollupDateBetweenOrderByRollupDateAsc(any(), any()))
                     .thenReturn(Collections.emptyList());
 
@@ -204,11 +204,11 @@ class AnalyticsServiceTest {
             Category category = buildCategory(UUID.randomUUID(), "Figures");
             Product product = buildProduct(productId, "Hot Figure", "FIG-002", category);
 
-            when(productRepository.findAllWithCategories()).thenReturn(List.of(product));
-            when(categoryRepository.findAll()).thenReturn(List.of(category));
-            when(inventoryTotalsRepository.findAllStockTotalsMap()).thenReturn(Map.of(productId, 50));
             when(forecastPredictionRepository.findAllLatest())
                     .thenReturn(List.of(buildPrediction(productId)));
+            when(productRepository.findByIdInWithCategories(any())).thenReturn(List.of(product));
+            when(categoryRepository.findAll()).thenReturn(List.of(category));
+            when(inventoryTotalsRepository.findAllStockTotalsMap()).thenReturn(Map.of(productId, 50));
             when(dailySalesRollupRepository.findByRollupDateBetweenOrderByRollupDateAsc(any(), any()))
                     .thenReturn(Collections.emptyList());
 
@@ -231,8 +231,9 @@ class AnalyticsServiceTest {
                     .thenReturn(Collections.emptyList());
             when(dailySalesRollupRepository.findByRollupDateBetweenOrderByRollupDateAsc(any(), any()))
                     .thenReturn(Collections.emptyList());
+            // Updated to include cost and profit columns
             when(dailySalesRollupRepository.getTotalsForPeriod(any(), any()))
-                    .thenReturn(Collections.singletonList(new Object[]{0L, BigDecimal.ZERO}));
+                    .thenReturn(Collections.singletonList(new Object[]{0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO}));
 
             SalesSummaryDTO result = analyticsService.getSalesSummary();
 
@@ -252,7 +253,8 @@ class AnalyticsServiceTest {
         @DisplayName("returns monthly and daily sales from rollup data")
         void returnsMonthlySalesFromRollupData() {
             LocalDate today = LocalDate.now();
-            Object[] monthlyRow = new Object[]{today.getYear(), today.getMonthValue(), 100, BigDecimal.valueOf(500.00)};
+            // Updated to include cost, profit, and unique_items columns
+            Object[] monthlyRow = new Object[]{today.getYear(), today.getMonthValue(), 100, BigDecimal.valueOf(500.00), BigDecimal.ZERO, BigDecimal.valueOf(500.00), 5};
             List<Object[]> monthlyRows = new java.util.ArrayList<>();
             monthlyRows.add(monthlyRow);
             when(dailySalesRollupRepository.aggregateByMonth(any(LocalDate.class)))
@@ -264,12 +266,15 @@ class AnalyticsServiceTest {
                     .rollupDate(today)
                     .unitsSold(25)
                     .revenue(BigDecimal.valueOf(125.00))
+                    .cost(BigDecimal.ZERO)
+                    .profit(BigDecimal.valueOf(125.00))
                     .movementCount(3)
                     .build();
             when(dailySalesRollupRepository.findByRollupDateBetweenOrderByRollupDateAsc(any(), any()))
                     .thenReturn(List.of(rollup));
+            // Updated to include cost and profit columns
             when(dailySalesRollupRepository.getTotalsForPeriod(any(), any()))
-                    .thenReturn(Collections.singletonList(new Object[]{100L, BigDecimal.valueOf(500.00)}));
+                    .thenReturn(Collections.singletonList(new Object[]{100L, BigDecimal.valueOf(500.00), BigDecimal.ZERO, BigDecimal.valueOf(500.00)}));
 
             SalesSummaryDTO result = analyticsService.getSalesSummary();
 


### PR DESCRIPTION
- Add admin-only endpoint POST /analytics/recompute-rollups for recalculating sales rollups after MSRP updates
- Optimize rollup recomputation using SQL aggregation (180x faster)
- Add cost and profit columns to DailySalesRollup entity and DTOs
- Add area chart view showing revenue vs cost over time
- Add frontend mutation hook with 3-minute timeout support
- Update MSRP script to filter to parent products only
- Batch existence checks to avoid N+1 queries in seed service