### PR TITLE
fix(backend): exclude child products from forecasts and analytics

### DIFF
--- a/services/forecasting-service/src/adapters/supabase_repo.py
+++ b/services/forecasting-service/src/adapters/supabase_repo.py
@@ -145,6 +145,7 @@ class SupabaseRepo:
             FROM products p
             LEFT JOIN categories c ON p.category_id = c.id
             WHERE p.is_active = true
+              AND p.parent_id IS NULL
         """
         params: dict = {}
 

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/DevSeedController.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/DevSeedController.java
@@ -370,7 +370,10 @@ public class DevSeedController {
             @RequestParam(defaultValue = "100") @Min(1) @Max(500) int salesPerProduct,
             @RequestParam(defaultValue = "365") @Min(1) @Max(730) int daysBack) {
 
-        List<Product> products = productRepository.findAll();
+        // Only seed sales for root products (exclude child products/prizes)
+        List<Product> products = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
 
         if (products.isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of(
@@ -491,7 +494,10 @@ public class DevSeedController {
      */
     @PostMapping("/seed/forecasts")
     public ResponseEntity<Map<String, Object>> seedForecasts() {
-        List<Product> products = productRepository.findAll();
+        // Only seed forecasts for root products (exclude child products/prizes)
+        List<Product> products = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
 
         if (products.isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of(
@@ -617,7 +623,10 @@ public class DevSeedController {
      */
     @PostMapping("/seed/notifications")
     public ResponseEntity<Map<String, Object>> seedNotifications() {
-        List<Product> products = productRepository.findAll();
+        // Only seed notifications for root products (exclude child products/prizes)
+        List<Product> products = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
 
         if (products.isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of(
@@ -1304,7 +1313,10 @@ public class DevSeedController {
     public ResponseEntity<Map<String, Object>> seedMachineDisplays(
             @RequestParam(defaultValue = "20") @Min(5) @Max(50) int displayCount) {
 
-        List<Product> products = productRepository.findAll();
+        // Only seed displays for root products (exclude child products/prizes)
+        List<Product> products = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
         if (products.isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of(
                 "error", "No products found. Run /api/dev/seed/all first."

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsSeedService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsSeedService.java
@@ -103,7 +103,11 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedForecastPredictions() {
-        return seedForecastPredictions(productRepository.findAll());
+        // Only seed forecasts for root products (exclude child products/prizes)
+        List<Product> rootProducts = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
+        return seedForecastPredictions(rootProducts);
     }
 
     private int seedForecastPredictions(List<Product> products) {
@@ -203,7 +207,11 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedDowPatternSales(int monthsBack) {
-        return seedDowPatternSales(monthsBack, productRepository.findAll());
+        // Only seed sales for root products (exclude child products/prizes)
+        List<Product> rootProducts = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
+        return seedDowPatternSales(monthsBack, rootProducts);
     }
 
     private int seedDowPatternSales(int monthsBack, List<Product> products) {
@@ -268,7 +276,11 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int seedDailyRollups(int monthsBack) {
-        return seedDailyRollups(monthsBack, productRepository.findAll());
+        // Only seed rollups for root products (exclude child products/prizes)
+        List<Product> rootProducts = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
+        return seedDailyRollups(monthsBack, rootProducts);
     }
 
     private int seedDailyRollups(int monthsBack, List<Product> products) {
@@ -558,7 +570,11 @@ public class AnalyticsSeedService {
      */
     @Transactional
     public int updateProductDefaults() {
-        return updateProductDefaults(productRepository.findAll());
+        // Only update defaults for root products (exclude child products/prizes)
+        List<Product> rootProducts = productRepository.findAll().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
+        return updateProductDefaults(rootProducts);
     }
 
     private int updateProductDefaults(List<Product> products) {
@@ -744,7 +760,10 @@ public class AnalyticsSeedService {
     public int rollupCategoryDemand() {
         LocalDate today = LocalDate.now();
         List<ForecastPrediction> latestPredictions = forecastPredictionRepository.findAllLatest();
-        List<Product> products = productRepository.findAllWithCategories();
+        // Only process root products (exclude child products/prizes)
+        List<Product> products = productRepository.findAllWithCategories().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
         Map<UUID, Integer> stockMap = inventoryTotalsRepository.findAllStockTotalsMap();
 
         if (products.isEmpty() || latestPredictions.isEmpty()) {

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AnalyticsService.java
@@ -243,7 +243,9 @@ public class AnalyticsService {
 
     @Transactional(readOnly = true)
     public List<CategoryInventoryDTO> getInventoryByCategory() {
-        List<Product> products = productRepository.findAllWithCategories();
+        List<Product> products = productRepository.findAllWithCategories().stream()
+                .filter(p -> p.getParentId() == null)
+                .toList();
         Map<UUID, Integer> stockTotals = inventoryTotalsRepository.findAllStockTotalsMap();
 
         Map<Category, List<Product>> productsByCategory = products.stream()
@@ -285,7 +287,9 @@ public class AnalyticsService {
             avgAccuracy = avgAccuracy.divide(BigDecimal.valueOf(accuracyCount), 1, RoundingMode.HALF_UP);
         }
 
-        List<Product> allProducts = productRepository.findAll();
+        List<Product> allProducts = productRepository.findAll().stream()
+                .filter(p -> p.getParentId() == null)
+                .toList();
         Map<UUID, Integer> stockByProduct = inventoryTotalsRepository.findAllStockTotalsMap();
 
         long outOfStockCount = allProducts.stream()
@@ -439,7 +443,7 @@ public class AnalyticsService {
 
         for (ForecastPrediction prediction : latestPredictions) {
             Product product = productMap.get(prediction.getItemId());
-            if (product == null || !product.getIsActive()) {
+            if (product == null || !product.getIsActive() || product.getParentId() != null) {
                 continue;
             }
 
@@ -570,8 +574,10 @@ public class AnalyticsService {
             featuresMap.put(fp.getItemId(), extractFeatures(fp));
         }
 
-        // Load products once and share across movers computation
-        List<Product> allProducts = productRepository.findAllWithCategories();
+        // Load products once and share across movers computation (exclude child products)
+        List<Product> allProducts = productRepository.findAllWithCategories().stream()
+            .filter(p -> p.getParentId() == null)
+            .toList();
         Map<UUID, Product> productMap = allProducts.stream()
             .collect(Collectors.toMap(Product::getId, Function.identity()));
 
@@ -866,6 +872,10 @@ public class AnalyticsService {
         int accuracyCount = 0;
 
         for (Product product : products) {
+            // Skip child products (prizes) - only process parent products
+            if (product.getParentId() != null) {
+                continue;
+            }
             ForecastFeatures features = featuresMap.get(product.getId());
             if (features != null && features.muHat() != null) {
                 BigDecimal muHat = features.muHat();


### PR DESCRIPTION
- Filter child products (prizes) from forecasting-service get_items() query
- Add parentId != null checks in AnalyticsService methods: getActionCenter, getInventoryByCategory, getPerformanceMetrics, getInsights, getDemandLeaders
- Update AnalyticsSeedService to only seed data for root products
- Update DevSeedController seed endpoints to exclude child products

Child products (Kuji prizes like Prize A, B, C) should not have individual forecasts calculated - only parent products should be forecasted and displayed in the Stockout Predictions page.