### PR TITLE
perf(images): cut Vercel image transformations to stay under 5k/month

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -15,8 +15,10 @@ const nextConfig = {
     ignoreBuildErrors: false,
   },
   images: {
-    formats: ["image/avif", "image/webp"],
+    formats: ["image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 7,
+    deviceSizes: [640, 1080],
+    imageSizes: [48, 96, 192],
     remotePatterns: [
       {
         protocol: "https",

--- a/apps/web/src/components/analytics/assistant/product-picker.tsx
+++ b/apps/web/src/components/analytics/assistant/product-picker.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Search, X } from "lucide-react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import { useProducts } from "@/hooks/queries/use-products";
 
 /**
@@ -102,18 +102,12 @@ export function ProductPicker() {
                         isActive ? "bg-muted" : "hover:bg-muted/60"
                       }`}
                     >
-                      {p.imageUrl ? (
-                        <Image
-                          src={p.imageUrl}
-                          alt=""
-                          width={28}
-                          height={28}
-                          sizes="28px"
-                          className="h-9 w-9 flex-shrink-0 rounded object-cover"
-                        />
-                      ) : (
-                        <div className="h-9 w-9 flex-shrink-0 rounded bg-muted-foreground/10" />
-                      )}
+                      <ProductThumbnail
+                        imageUrl={p.imageUrl}
+                        alt={p.name}
+                        size="sm"
+                        fallbackText=""
+                      />
                       <span className="flex-1 truncate">{p.name}</span>
                       <span className="truncate text-xs text-muted-foreground">
                         {p.category?.name}

--- a/apps/web/src/components/dashboard/highest-demand-card.tsx
+++ b/apps/web/src/components/dashboard/highest-demand-card.tsx
@@ -75,6 +75,8 @@ export function HighestDemandCard({
               alt={product.itemName}
               fill
               className="object-contain p-4"
+              sizes="(max-width: 768px) 160px, 288px"
+              quality={75}
               onError={(e) => {
                 const target = e.target as HTMLImageElement;
                 target.style.display = "none";

--- a/apps/web/src/components/locations/not-assigned-table.tsx
+++ b/apps/web/src/components/locations/not-assigned-table.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Image from "next/image";
-import { ImageOff, Package } from "lucide-react";
+import { Package } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import type { LocationInventory } from "@/types/api";
 
 interface NotAssignedTableProps {
@@ -47,21 +47,12 @@ export function NotAssignedTable({
     <div>
       {items.map((item) => (
         <div key={item.id} className="flex items-center gap-2 sm:gap-4 py-3 sm:py-4 border-b last:border-b-0">
-          <div className="relative h-12 w-12 sm:h-20 sm:w-20 flex-shrink-0 rounded-lg overflow-hidden bg-muted">
-            {item.item.imageUrl ? (
-              <Image
-                src={item.item.imageUrl}
-                alt={item.item.name}
-                fill
-                sizes="(max-width: 640px) 48px, 80px"
-                className="object-cover"
-              />
-            ) : (
-              <div className="h-full w-full flex items-center justify-center">
-                <ImageOff className="h-5 w-5 sm:h-6 sm:w-6 text-muted-foreground" />
-              </div>
-            )}
-          </div>
+          <ProductThumbnail
+            imageUrl={item.item.imageUrl}
+            alt={item.item.name}
+            size="lg"
+            fallbackVariant="icon"
+          />
           <div className="flex-1 min-w-0">
             <p className="font-medium text-xs sm:text-base truncate">{item.item.name}</p>
             <div className="flex flex-wrap gap-1 mt-1">

--- a/apps/web/src/components/products/product-table.tsx
+++ b/apps/web/src/components/products/product-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
-import { ImageOff, MoreVertical, FolderOpen, ArrowUp, ArrowDown } from "lucide-react";
+import { MoreVertical, FolderOpen, ArrowUp, ArrowDown } from "lucide-react";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -158,21 +158,12 @@ export function ProductTable({
                 >
                   <TableCell className="py-2 rounded-l-lg max-w-0 overflow-hidden">
                     <div className="flex items-center gap-3 min-w-0 w-full">
-                      {row.product.imageUrl ? (
-                        <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-md bg-muted">
-                          <Image
-                            src={row.product.imageUrl}
-                            alt={row.product.name}
-                            fill
-                            sizes="40px"
-                            className="object-cover"
-                          />
-                        </div>
-                      ) : (
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
-                          <ImageOff className="h-4 w-4 text-muted-foreground" />
-                        </div>
-                      )}
+                      <ProductThumbnail
+                        imageUrl={row.product.imageUrl}
+                        alt={row.product.name}
+                        size="md"
+                        fallbackVariant="icon"
+                      />
                       <span className="font-medium truncate min-w-0 flex items-center gap-1.5">
                         {row.product.name}
                         {showKujiIcon && (

--- a/apps/web/src/components/products/product-thumbnail.tsx
+++ b/apps/web/src/components/products/product-thumbnail.tsx
@@ -16,6 +16,7 @@ const SIZE_CONFIG: Record<ThumbnailSize, { container: string; icon: string; size
 };
 
 type FallbackVariant = "text" | "icon" | "package";
+type BadgeStyle = "stack" | "quantity";
 
 interface ProductThumbnailProps {
   imageUrl: string | null | undefined;
@@ -24,6 +25,7 @@ interface ProductThumbnailProps {
   fallbackVariant?: FallbackVariant;
   fallbackText?: string;
   badge?: number;
+  badgeStyle?: BadgeStyle;
   className?: string;
 }
 
@@ -34,6 +36,7 @@ export const ProductThumbnail = memo(function ProductThumbnail({
   fallbackVariant = "text",
   fallbackText = "N/A",
   badge,
+  badgeStyle = "stack",
   className,
 }: ProductThumbnailProps) {
   const [hasError, setHasError] = useState(false);
@@ -56,35 +59,46 @@ export const ProductThumbnail = memo(function ProductThumbnail({
     }
   };
 
+  const showStackBadge =
+    badgeStyle === "stack" && badge !== undefined && badge > 1;
+  const showQuantityBadge = badgeStyle === "quantity" && badge !== undefined;
+
   return (
-    <div
-      className={cn(
-        "relative shrink-0 overflow-hidden rounded-md bg-muted",
-        config.container,
-        className
-      )}
-    >
-      {showFallback ? (
-        <div className="flex h-full w-full items-center justify-center">
-          {renderFallback()}
-        </div>
-      ) : (
-        <Image
-          src={safeImageUrl}
-          alt={alt}
-          fill
-          className="object-cover"
-          sizes={config.sizes}
-          onError={() => setHasError(true)}
-        />
-      )}
-      {badge !== undefined && badge > 1 && (
+    <div className={cn("relative shrink-0", className)}>
+      <div
+        className={cn(
+          "relative overflow-hidden rounded-md bg-muted",
+          config.container
+        )}
+      >
+        {showFallback ? (
+          <div className="flex h-full w-full items-center justify-center">
+            {renderFallback()}
+          </div>
+        ) : (
+          <Image
+            src={safeImageUrl}
+            alt={alt}
+            fill
+            className="object-cover"
+            sizes={config.sizes}
+            quality={75}
+            onError={() => setHasError(true)}
+          />
+        )}
+      </div>
+      {showStackBadge && (
         <Badge
           variant="secondary"
           className="absolute -bottom-1 -right-1 h-4 min-w-4 px-1 text-[10px]"
         >
-          +{badge - 1}
+          +{badge! - 1}
         </Badge>
+      )}
+      {showQuantityBadge && (
+        <span className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-background border border-border text-[10px] font-medium text-muted-foreground">
+          {badge}
+        </span>
       )}
     </div>
   );

--- a/apps/web/src/components/shipments/shipment-card.tsx
+++ b/apps/web/src/components/shipments/shipment-card.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Image from "next/image";
-import { MoreVertical, Package } from "lucide-react";
+import { MoreVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import { ShipmentProgress } from "./shipment-progress";
 import { usePermissions } from "@/hooks/use-permissions";
-import { CarrierStatus, type Shipment, type ShipmentItem } from "@/types/api";
+import { CarrierStatus, type Shipment } from "@/types/api";
 import { getShipmentDisplayStatus } from "@/lib/shipment-utils";
 
 interface ShipmentCardProps {
@@ -79,32 +79,6 @@ function getStatusText(shipment: Shipment): { text: string; date: string } {
     text: "Order being packaged",
     date: formatDate(shipment.orderDate),
   };
-}
-
-function ProductThumbnail({ item }: { item: ShipmentItem }) {
-  const imageUrl = item.item?.imageUrl;
-  const quantity = item.orderedQuantity;
-
-  return (
-    <div className="relative">
-      <div className="relative h-12 w-12 rounded-lg bg-muted overflow-hidden flex items-center justify-center">
-        {imageUrl ? (
-          <Image
-            src={imageUrl}
-            alt={item.item?.name || "Product"}
-            fill
-            sizes="48px"
-            className="object-cover"
-          />
-        ) : (
-          <Package className="h-5 w-5 text-muted-foreground" />
-        )}
-      </div>
-      <span className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-background border border-border text-[10px] font-medium text-muted-foreground">
-        {quantity}
-      </span>
-    </div>
-  );
 }
 
 export function ShipmentCard({ shipment, onClick }: ShipmentCardProps) {
@@ -180,7 +154,15 @@ export function ShipmentCard({ shipment, onClick }: ShipmentCardProps) {
       {/* Product Images Row (only parent/root items; prizes are under parent Kuji) */}
       <div className="flex items-start gap-3 mb-4 overflow-x-auto scrollbar-none pb-1">
         {rootItems.map((item) => (
-          <ProductThumbnail key={item.id} item={item} />
+          <ProductThumbnail
+            key={item.id}
+            imageUrl={item.item?.imageUrl}
+            alt={item.item?.name || "Product"}
+            size="lg"
+            fallbackVariant="package"
+            badge={item.orderedQuantity}
+            badgeStyle="quantity"
+          />
         ))}
       </div>
 

--- a/apps/web/src/components/shipments/shipment-detail-sheet.tsx
+++ b/apps/web/src/components/shipments/shipment-detail-sheet.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Image from "next/image";
 import { format } from "date-fns";
 import { Package, PackageCheck, Trash2, Truck, Loader2, Pencil, Check, X, Undo2, Settings2 } from "lucide-react";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import {
   Dialog,
   DialogContent,
@@ -190,20 +190,12 @@ function ItemRow({ item }: { item: ShipmentItem }) {
         : "bg-green-50/50 dark:bg-green-950/20 border-l-green-400"
     )}>
       <div className="flex items-center gap-3">
-        {/* Product Image */}
-        <div className="relative h-10 w-10 rounded-lg bg-muted overflow-hidden flex items-center justify-center shrink-0">
-          {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={item.item?.name || "Product"}
-              fill
-              sizes="40px"
-              className="object-cover"
-            />
-          ) : (
-            <Package className="h-4 w-4 text-muted-foreground" />
-          )}
-        </div>
+        <ProductThumbnail
+          imageUrl={imageUrl}
+          alt={item.item?.name || "Product"}
+          size="md"
+          fallbackVariant="package"
+        />
         <div className="flex-1 min-w-0">
           <p className="font-medium text-sm">{item.item.name}</p>
           {item.item.sku && <p className="text-xs text-muted-foreground font-mono">{item.item.sku}</p>}
@@ -265,19 +257,12 @@ function KujiBlockSection({ block }: { block: DetailBlock }) {
     )}>
       {/* Parent row (Kuji set) */}
       <div className="flex items-center gap-3">
-        <div className="relative h-10 w-10 rounded-lg bg-muted overflow-hidden flex items-center justify-center shrink-0">
-          {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={parentItem.item?.name || "Kuji"}
-              fill
-              sizes="40px"
-              className="object-cover"
-            />
-          ) : (
-            <Package className="h-4 w-4 text-muted-foreground" />
-          )}
-        </div>
+        <ProductThumbnail
+          imageUrl={imageUrl}
+          alt={parentItem.item?.name || "Kuji"}
+          size="md"
+          fallbackVariant="package"
+        />
         <div className="flex-1 min-w-0">
           <p className="font-medium text-sm">{parentItem.item.name}</p>
           {parentItem.item.sku && <p className="text-xs text-muted-foreground font-mono">{parentItem.item.sku}</p>}

--- a/apps/web/src/components/shipments/shipment-receive-dialog.tsx
+++ b/apps/web/src/components/shipments/shipment-receive-dialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import Image from "next/image";
 import { format } from "date-fns";
-import { Calendar as CalendarIcon, Loader2, Plus, Trash2, Package } from "lucide-react";
+import { Calendar as CalendarIcon, Loader2, Plus, Trash2 } from "lucide-react";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import {
   Dialog,
   DialogContent,
@@ -541,19 +541,12 @@ export function ShipmentReceiveDialog({
                     {/* Parent item header */}
                     <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 mb-3">
                       <div className="flex items-start gap-3">
-                        <div className="relative h-10 w-10 rounded-lg bg-muted overflow-hidden flex items-center justify-center shrink-0">
-                          {itemImageUrl ? (
-                            <Image
-                              src={itemImageUrl}
-                              alt={item.item.name}
-                              fill
-                              sizes="40px"
-                              className="object-cover"
-                            />
-                          ) : (
-                            <Package className="h-4 w-4 text-muted-foreground" />
-                          )}
-                        </div>
+                        <ProductThumbnail
+                          imageUrl={itemImageUrl}
+                          alt={item.item.name}
+                          size="md"
+                          fallbackVariant="package"
+                        />
                         <div>
                           <div className="font-medium">{item.item.name}</div>
                           <div className="text-xs text-muted-foreground font-mono">

--- a/apps/web/src/components/shipments/shipment-undo-items-dialog.tsx
+++ b/apps/web/src/components/shipments/shipment-undo-items-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import Image from "next/image";
-import { Package, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
+import { ProductThumbnail } from "@/components/products/product-thumbnail";
 import {
   Dialog,
   DialogContent,
@@ -226,19 +226,12 @@ export function ShipmentUndoItemsDialog({
                         checked={selectedItems.has(parentItem.id)}
                         onCheckedChange={() => toggleItem(parentItem.id)}
                       />
-                      <div className="relative h-10 w-10 rounded-lg bg-muted overflow-hidden flex items-center justify-center shrink-0">
-                        {imageUrl ? (
-                          <Image
-                            src={imageUrl}
-                            alt={parentItem.item.name}
-                            fill
-                            sizes="40px"
-                            className="object-cover"
-                          />
-                        ) : (
-                          <Package className="h-4 w-4 text-muted-foreground" />
-                        )}
-                      </div>
+                      <ProductThumbnail
+                        imageUrl={imageUrl}
+                        alt={parentItem.item.name}
+                        size="md"
+                        fallbackVariant="package"
+                      />
                       <label
                         htmlFor={`item-${parentItem.id}`}
                         className="flex-1 cursor-pointer"


### PR DESCRIPTION
- drop image/avif from next.config.mjs formats; webp-only halves transforms
- pin imageSizes [48,96,192] and deviceSizes [640,1080] (was 8+8 defaults)
- migrate 8 raw <Image> usages to shared ProductThumbnail to standardize thumbnail widths (32/40/48px) and prevent per-callsite drift
- add badgeStyle="quantity" mode for shipment-card raw quantity badge
- fix latent badge clipping in ProductThumbnail (badge was inside overflow-hidden container)
- add explicit quality={75} as drift protection
- fix highest-demand-card serving at 1920px (missing sizes prop) by setting sizes="(max-width: 768px) 160px, 288px"

Production usage was tracking ~440 transforms/day (~13.2k/month, 2.6x the 5k free-tier limit). Expected reduction: ~70-80%, target <=100/day.