### PR TITLE
feat(shipments): add shipment audit detail and fix reversal duplication

### DIFF
--- a/apps/web/src/components/audit-log/audit-log-table.tsx
+++ b/apps/web/src/components/audit-log/audit-log-table.tsx
@@ -12,6 +12,9 @@ import {
 } from "@/types/api";
 import { useAuditLogDetail } from "@/hooks/queries/use-audit-log";
 import { cn } from "@/lib/utils";
+import { ShipmentEditedDetail } from "./expanded-rows/shipment-edited-detail";
+import { ShipmentDeletedDetail } from "./expanded-rows/shipment-deleted-detail";
+import { ShipmentStatusOverriddenDetail } from "./expanded-rows/shipment-status-overridden-detail";
 
 const REASON_LABELS: Record<StockMovementReason, string> = {
   [StockMovementReason.INITIAL_STOCK]: "Initial Stock",
@@ -135,6 +138,29 @@ function ExpandedDetail({ auditLogId }: { auditLogId: string }) {
   if (!detail) return null;
 
   const isDisplayOperation = DISPLAY_REASONS.has(detail.reason);
+
+  // Shipment lifecycle events use structured columns instead of stock movements.
+  if (detail.reason === StockMovementReason.SHIPMENT_EDITED) {
+    return (
+      <div className="px-4 md:px-12 pb-4 pt-1">
+        <ShipmentEditedDetail detail={detail} />
+      </div>
+    );
+  }
+  if (detail.reason === StockMovementReason.SHIPMENT_DELETED) {
+    return (
+      <div className="px-4 md:px-12 pb-4 pt-1">
+        <ShipmentDeletedDetail detail={detail} />
+      </div>
+    );
+  }
+  if (detail.reason === StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN) {
+    return (
+      <div className="px-4 md:px-12 pb-4 pt-1">
+        <ShipmentStatusOverriddenDetail detail={detail} />
+      </div>
+    );
+  }
 
   return (
     <div className="px-4 md:px-12 pb-4 pt-1">

--- a/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-deleted-detail.test.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-deleted-detail.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ShipmentDeletedDetail } from "../shipment-deleted-detail";
+import { AuditLogDetail, StockMovementReason } from "@/types/api";
+
+function buildDetail(fieldChanges: AuditLogDetail["fieldChanges"]): AuditLogDetail {
+  return {
+    id: "log-1",
+    actorName: "Carol",
+    reason: StockMovementReason.SHIPMENT_DELETED,
+    itemCount: 2,
+    totalQuantityMoved: 0,
+    createdAt: "2026-04-30T12:00:00Z",
+    movements: [],
+    fieldChanges,
+  };
+}
+
+describe("ShipmentDeletedDetail", () => {
+  it("renders supplier when provided as a value entry", () => {
+    render(
+      <ShipmentDeletedDetail
+        detail={buildDetail([
+          { field: "supplier", value: "Acme Corp" },
+          { field: "deleted_items", to: [] },
+        ])}
+      />
+    );
+    expect(screen.getByText(/Supplier:/)).toBeInTheDocument();
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+  });
+
+  it("renders deleted items with ordered/received columns", () => {
+    render(
+      <ShipmentDeletedDetail
+        detail={buildDetail([
+          {
+            field: "deleted_items",
+            from: null,
+            to: [
+              { name: "Widget A", ordered: 10, received: 5 },
+              { name: "Widget B", ordered: 20, received: 0 },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText("Widget A")).toBeInTheDocument();
+    expect(screen.getByText("Widget B")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+  });
+
+  it("shows an empty-state when no items captured", () => {
+    render(<ShipmentDeletedDetail detail={buildDetail([])} />);
+    expect(screen.getByText(/No items captured/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-edited-detail.test.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-edited-detail.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ShipmentEditedDetail } from "../shipment-edited-detail";
+import { AuditLogDetail, StockMovementReason } from "@/types/api";
+
+function buildDetail(fieldChanges: AuditLogDetail["fieldChanges"]): AuditLogDetail {
+  return {
+    id: "log-1",
+    actorName: "Alice",
+    reason: StockMovementReason.SHIPMENT_EDITED,
+    itemCount: 1,
+    totalQuantityMoved: 0,
+    createdAt: "2026-04-30T12:00:00Z",
+    movements: [],
+    fieldChanges,
+  };
+}
+
+describe("ShipmentEditedDetail", () => {
+  it("renders scalar field changes as FROM → TO rows", () => {
+    render(
+      <ShipmentEditedDetail
+        detail={buildDetail([
+          { field: "supplier", from: "Acme", to: "Globex" },
+          { field: "status", from: "PENDING", to: "RECEIVED" },
+        ])}
+      />
+    );
+    expect(screen.getByText("Supplier")).toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("Globex")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("PENDING")).toBeInTheDocument();
+    expect(screen.getByText("RECEIVED")).toBeInTheDocument();
+  });
+
+  it("renders 'Notes updated' without revealing note contents", () => {
+    render(<ShipmentEditedDetail detail={buildDetail([{ field: "notes", changed: true }])} />);
+    expect(screen.getByText("Notes updated")).toBeInTheDocument();
+  });
+
+  it("renders items added as a list", () => {
+    render(
+      <ShipmentEditedDetail
+        detail={buildDetail([
+          {
+            field: "items_added",
+            from: null,
+            to: [
+              { name: "Widget A", qty: 3 },
+              { name: "Widget B", qty: 5 },
+            ],
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText("Items added")).toBeInTheDocument();
+    expect(screen.getByText("Widget A")).toBeInTheDocument();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+    expect(screen.getByText("Widget B")).toBeInTheDocument();
+    expect(screen.getByText("(5)")).toBeInTheDocument();
+  });
+
+  it("renders items removed using the from side", () => {
+    render(
+      <ShipmentEditedDetail
+        detail={buildDetail([
+          { field: "items_removed", from: [{ name: "Old Item", qty: 2 }], to: null },
+        ])}
+      />
+    );
+    expect(screen.getByText("Items removed")).toBeInTheDocument();
+    expect(screen.getByText("Old Item")).toBeInTheDocument();
+  });
+
+  it("renders an empty-state when no changes are present", () => {
+    render(<ShipmentEditedDetail detail={buildDetail([])} />);
+    expect(screen.getByText(/No field changes recorded/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-status-overridden-detail.test.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/__tests__/shipment-status-overridden-detail.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ShipmentStatusOverriddenDetail } from "../shipment-status-overridden-detail";
+import { AuditLogDetail, StockMovementReason } from "@/types/api";
+
+function buildDetail(overrides: Partial<AuditLogDetail> = {}): AuditLogDetail {
+  return {
+    id: "log-1",
+    actorName: "Bob",
+    reason: StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN,
+    itemCount: 1,
+    totalQuantityMoved: 0,
+    createdAt: "2026-04-30T12:00:00Z",
+    movements: [],
+    ...overrides,
+  };
+}
+
+describe("ShipmentStatusOverriddenDetail", () => {
+  it("renders the previous → new status diff", () => {
+    render(
+      <ShipmentStatusOverriddenDetail
+        detail={buildDetail({ previousStatus: "PENDING", newStatus: "RECEIVED" })}
+      />
+    );
+    expect(screen.getByText("PENDING")).toBeInTheDocument();
+    expect(screen.getByText("RECEIVED")).toBeInTheDocument();
+  });
+
+  it("renders the override reason when present", () => {
+    render(
+      <ShipmentStatusOverriddenDetail
+        detail={buildDetail({
+          previousStatus: "PENDING",
+          newStatus: "RECEIVED",
+          overrideReason: "missing tracking; items received",
+        })}
+      />
+    );
+    expect(screen.getByText(/Reason/i)).toBeInTheDocument();
+    expect(screen.getByText("missing tracking; items received")).toBeInTheDocument();
+  });
+
+  it("hides the reason block when no override reason is set", () => {
+    render(
+      <ShipmentStatusOverriddenDetail
+        detail={buildDetail({ previousStatus: "PENDING", newStatus: "RECEIVED" })}
+      />
+    );
+    expect(screen.queryByText(/Reason/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to em-dash when status fields are missing", () => {
+    render(<ShipmentStatusOverriddenDetail detail={buildDetail()} />);
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/components/audit-log/expanded-rows/shipment-deleted-detail.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/shipment-deleted-detail.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { AuditLogDetail } from "@/types/api";
+
+interface DeletedItem {
+  name?: string;
+  ordered?: number;
+  received?: number;
+}
+
+export function ShipmentDeletedDetail({ detail }: { detail: AuditLogDetail }) {
+  const changes = detail.fieldChanges ?? [];
+  const supplierEntry = changes.find((c) => c.field === "supplier");
+  const supplier =
+    supplierEntry && typeof supplierEntry.value === "string" ? supplierEntry.value : null;
+
+  const deletedItemsEntry = changes.find((c) => c.field === "deleted_items");
+  const items: DeletedItem[] = Array.isArray(deletedItemsEntry?.to)
+    ? (deletedItemsEntry?.to as DeletedItem[])
+    : [];
+
+  return (
+    <div className="space-y-3">
+      {supplier && (
+        <div className="px-3 py-1 text-sm">
+          <span className="text-muted-foreground">Supplier: </span>
+          <span className="font-medium">{supplier}</span>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="px-3 py-2 text-sm text-muted-foreground italic">
+          No items captured at deletion time.
+        </div>
+      ) : (
+        <div className="space-y-1">
+          <div className="grid grid-cols-[1fr_5rem_5rem] gap-x-4 md:gap-x-8 px-3 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            <span>Product</span>
+            <span className="text-center">Ordered</span>
+            <span className="text-center">Received</span>
+          </div>
+          {items.map((item, idx) => (
+            <div
+              key={idx}
+              className="grid grid-cols-[1fr_5rem_5rem] gap-x-4 md:gap-x-8 px-3 py-2 rounded-md hover:bg-black/5 dark:hover:bg-white/5"
+            >
+              <span className="text-sm font-medium truncate">{item.name ?? "(unknown)"}</span>
+              <span className="text-sm text-muted-foreground text-center tabular-nums">
+                {item.ordered ?? 0}
+              </span>
+              <span className="text-sm text-muted-foreground text-center tabular-nums">
+                {item.received ?? 0}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/audit-log/expanded-rows/shipment-edited-detail.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/shipment-edited-detail.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { AuditLogDetail, AuditLogFieldChange } from "@/types/api";
+
+const FIELD_LABELS: Record<string, string> = {
+  supplier: "Supplier",
+  shipmentNumber: "Shipment #",
+  status: "Status",
+  orderDate: "Order date",
+  expectedDeliveryDate: "Expected date",
+  actualDeliveryDate: "Actual date",
+  totalCost: "Cost",
+  trackingId: "Tracking",
+  notes: "Notes",
+  items_added: "Items added",
+  items_removed: "Items removed",
+};
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+function ItemList({ items }: { items: unknown }) {
+  if (!Array.isArray(items)) return <span className="text-muted-foreground">—</span>;
+  return (
+    <ul className="space-y-0.5">
+      {items.map((it, idx) => {
+        const entry = it as { name?: string; qty?: number };
+        return (
+          <li key={idx} className="text-sm">
+            <span className="font-medium">{entry.name ?? "(unknown)"}</span>
+            {entry.qty != null && (
+              <span className="text-muted-foreground"> ({entry.qty})</span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function FieldRow({ change }: { change: AuditLogFieldChange }) {
+  const label = FIELD_LABELS[change.field] ?? change.field;
+
+  if (change.field === "notes") {
+    return (
+      <div className="grid grid-cols-[10rem_1fr] gap-x-6 px-3 py-2 rounded-md hover:bg-black/5 dark:hover:bg-white/5">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-sm text-muted-foreground italic">Notes updated</span>
+      </div>
+    );
+  }
+
+  if (change.field === "items_added" || change.field === "items_removed") {
+    const items = change.field === "items_added" ? change.to : change.from;
+    return (
+      <div className="grid grid-cols-[10rem_1fr] gap-x-6 px-3 py-2 rounded-md hover:bg-black/5 dark:hover:bg-white/5">
+        <span className="text-sm font-medium">{label}</span>
+        <ItemList items={items} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-[10rem_1fr_auto_1fr] items-center gap-x-3 md:gap-x-6 px-3 py-2 rounded-md hover:bg-black/5 dark:hover:bg-white/5">
+      <span className="text-sm font-medium">{label}</span>
+      <span className="text-sm text-muted-foreground tabular-nums truncate">
+        {formatValue(change.from)}
+      </span>
+      <span className="text-muted-foreground">→</span>
+      <span className="text-sm font-medium tabular-nums truncate">
+        {formatValue(change.to)}
+      </span>
+    </div>
+  );
+}
+
+export function ShipmentEditedDetail({ detail }: { detail: AuditLogDetail }) {
+  const changes = detail.fieldChanges ?? [];
+
+  if (changes.length === 0) {
+    return (
+      <div className="px-3 py-4 text-sm text-muted-foreground italic">
+        No field changes recorded.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="grid grid-cols-[10rem_1fr] gap-x-6 px-3 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        <span>Field</span>
+        <span>Change</span>
+      </div>
+      {changes.map((change, idx) => (
+        <FieldRow key={`${change.field}-${idx}`} change={change} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/audit-log/expanded-rows/shipment-status-overridden-detail.tsx
+++ b/apps/web/src/components/audit-log/expanded-rows/shipment-status-overridden-detail.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AuditLogDetail } from "@/types/api";
+
+export function ShipmentStatusOverriddenDetail({ detail }: { detail: AuditLogDetail }) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-[10rem_1fr_auto_1fr] items-center gap-x-3 md:gap-x-6 px-3 py-2 rounded-md hover:bg-black/5 dark:hover:bg-white/5">
+        <span className="text-sm font-medium">Status</span>
+        <span className="text-sm text-muted-foreground tabular-nums">
+          {detail.previousStatus ?? "—"}
+        </span>
+        <span className="text-muted-foreground">→</span>
+        <span className="text-sm font-medium tabular-nums">{detail.newStatus ?? "—"}</span>
+      </div>
+
+      {detail.overrideReason && (
+        <div className="px-3 py-2 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-100 dark:border-amber-900/40">
+          <p className="text-xs font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-1">
+            Reason
+          </p>
+          <p className="text-sm text-amber-900 dark:text-amber-200">{detail.overrideReason}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/shipments/shipment-undo-items-dialog.tsx
+++ b/apps/web/src/components/shipments/shipment-undo-items-dialog.tsx
@@ -26,7 +26,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { cn, prizeLetterDisplay, sortPrizes } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
-import { useUndoReceiveShipmentItemMutation } from "@/hooks/mutations/use-shipment-mutations";
+import { useUndoReceiveShipmentItemsMutation } from "@/hooks/mutations/use-shipment-mutations";
 import type { Shipment, ShipmentItem } from "@/types/api";
 
 interface ShipmentUndoItemsDialogProps {
@@ -57,7 +57,7 @@ export function ShipmentUndoItemsDialog({
   onSuccess,
 }: ShipmentUndoItemsDialogProps) {
   const { toast } = useToast();
-  const undoItemMutation = useUndoReceiveShipmentItemMutation();
+  const undoItemsMutation = useUndoReceiveShipmentItemsMutation();
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [isProcessing, setIsProcessing] = useState(false);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
@@ -129,40 +129,31 @@ export function ShipmentUndoItemsDialog({
     if (!shipment || selectedItems.size === 0) return;
 
     setIsProcessing(true);
-    let lastUpdatedShipment: Shipment | null = null;
-    let failedCount = 0;
     const itemsToUndo = Array.from(selectedItems);
 
-    for (const itemId of itemsToUndo) {
-      try {
-        lastUpdatedShipment = await undoItemMutation.mutateAsync({
-          shipmentId: shipment.id,
-          itemId,
-        });
-      } catch (err: unknown) {
-        failedCount++;
-        const message =
-          err instanceof Error ? err.message : "Failed to undo item";
-        toast({
-          title: "Error undoing item",
-          description: message,
-          variant: "destructive",
-        });
-      }
-    }
+    try {
+      const updatedShipment = await undoItemsMutation.mutateAsync({
+        shipmentId: shipment.id,
+        itemIds: itemsToUndo,
+      });
 
-    setIsProcessing(false);
-
-    const successCount = itemsToUndo.length - failedCount;
-    if (successCount > 0) {
       toast({
-        title: `${successCount} item${successCount > 1 ? "s" : ""} reversed`,
+        title: `${itemsToUndo.length} item${itemsToUndo.length > 1 ? "s" : ""} reversed`,
         description: "Inventory has been restored for the selected items.",
       });
-      if (lastUpdatedShipment && onSuccess) {
-        onSuccess(lastUpdatedShipment);
+      if (onSuccess) {
+        onSuccess(updatedShipment);
       }
       onOpenChange(false);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to undo items";
+      toast({
+        title: "Error undoing items",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsProcessing(false);
     }
   }
 

--- a/apps/web/src/hooks/mutations/use-shipment-mutations.ts
+++ b/apps/web/src/hooks/mutations/use-shipment-mutations.ts
@@ -7,6 +7,7 @@ import {
   deleteShipment,
   receiveShipment,
   undoReceiveShipmentItem,
+  undoReceiveShipmentItems,
   overrideShipmentStatus,
   type OverrideShipmentStatusRequest,
 } from "@/lib/api/shipments";
@@ -66,6 +67,18 @@ export function useUndoReceiveShipmentItemMutation() {
   return useMutation<Shipment, Error, { shipmentId: string; itemId: string }>({
     mutationFn: ({ shipmentId, itemId }) =>
       undoReceiveShipmentItem(shipmentId, itemId),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["shipments"] });
+      await qc.invalidateQueries({ queryKey: ["products"] });
+    },
+  });
+}
+
+export function useUndoReceiveShipmentItemsMutation() {
+  const qc = useQueryClient();
+  return useMutation<Shipment, Error, { shipmentId: string; itemIds: string[] }>({
+    mutationFn: ({ shipmentId, itemIds }) =>
+      undoReceiveShipmentItems(shipmentId, itemIds),
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ["shipments"] });
       await qc.invalidateQueries({ queryKey: ["products"] });

--- a/apps/web/src/lib/api/shipments.ts
+++ b/apps/web/src/lib/api/shipments.ts
@@ -137,6 +137,21 @@ export async function undoReceiveShipmentItem(
 }
 
 /**
+ * Undo receipt for multiple shipment items in one transaction. Produces exactly one
+ * audit log row covering the whole batch — preferred over the per-item endpoint when
+ * the user selects multiple items at once.
+ */
+export async function undoReceiveShipmentItems(
+  shipmentId: string,
+  itemIds: string[]
+): Promise<Shipment> {
+  return apiPost<Shipment, { itemIds: string[] }>(
+    `${BASE_PATH}/${shipmentId}/undo-receive`,
+    { itemIds }
+  );
+}
+
+/**
  * Manually override a shipment's inventory status. Reason is required.
  */
 export async function overrideShipmentStatus(

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -479,6 +479,15 @@ export interface AuditLogFilters {
   locationId?: string;
 }
 
+// Field-change entries inside audit_logs.field_changes for SHIPMENT_EDITED / SHIPMENT_DELETED
+export interface AuditLogFieldChange {
+  field: string;
+  from?: unknown;
+  to?: unknown;
+  changed?: boolean;
+  value?: unknown;
+}
+
 // New audit log types (grouped actions)
 export interface AuditLog {
   id: string;
@@ -492,6 +501,12 @@ export interface AuditLog {
   notes?: string;
   createdAt: string;
   productSummary: string;
+  shipmentId?: string;
+  shipmentNumber?: string;
+  fieldChanges?: AuditLogFieldChange[];
+  previousStatus?: string;
+  newStatus?: string;
+  overrideReason?: string;
 }
 
 export interface AuditLogMovement {
@@ -519,6 +534,12 @@ export interface AuditLogDetail {
   productSummary?: string;
   notes?: string;
   createdAt: string;
+  shipmentId?: string;
+  shipmentNumber?: string;
+  fieldChanges?: AuditLogFieldChange[];
+  previousStatus?: string;
+  newStatus?: string;
+  overrideReason?: string;
   movements: AuditLogMovement[];
 }
 

--- a/infra/init-db/08-shipment-audit-columns.sql
+++ b/infra/init-db/08-shipment-audit-columns.sql
@@ -1,0 +1,19 @@
+-- Shipment Audit Columns: structured columns for shipment lifecycle events on audit_logs
+-- Inventory rows leave these null; shipment events populate the relevant subset.
+
+ALTER TABLE audit_logs
+    ADD COLUMN IF NOT EXISTS shipment_id        UUID,
+    ADD COLUMN IF NOT EXISTS shipment_number    VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS field_changes      JSONB,
+    ADD COLUMN IF NOT EXISTS previous_status    VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS new_status         VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS override_reason    TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_shipment_id ON audit_logs(shipment_id);
+
+COMMENT ON COLUMN audit_logs.shipment_id IS 'Parent shipment for shipment-related audits (no FK; audit log is denormalized history)';
+COMMENT ON COLUMN audit_logs.shipment_number IS 'Denormalized shipment number for display when the shipment is gone';
+COMMENT ON COLUMN audit_logs.field_changes IS 'JSON array of {field, from, to} for SHIPMENT_EDITED, or {field: deleted_items, to: [...]} for SHIPMENT_DELETED';
+COMMENT ON COLUMN audit_logs.previous_status IS 'Status before override (SHIPMENT_STATUS_OVERRIDDEN only)';
+COMMENT ON COLUMN audit_logs.new_status IS 'Status after override (SHIPMENT_STATUS_OVERRIDDEN only)';
+COMMENT ON COLUMN audit_logs.override_reason IS 'User-supplied reason for SHIPMENT_STATUS_OVERRIDDEN';

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/ShipmentController.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/controllers/ShipmentController.java
@@ -163,6 +163,20 @@ public class ShipmentController {
         return ResponseEntity.ok(shipmentMapperDecorator.toResponseDTOWithLocationCodes(shipment));
     }
 
+    public record UndoReceiveRequest(java.util.List<UUID> itemIds) {}
+
+    @PostMapping("/{shipmentId}/undo-receive")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ASSISTANT_MANAGER')")
+    public ResponseEntity<ShipmentResponseDTO> undoReceiveShipmentItems(
+            @PathVariable UUID shipmentId,
+            @RequestBody UndoReceiveRequest request,
+            Authentication authentication) {
+        ActorInfo actor = getActorInfo(authentication);
+        Shipment shipment = shipmentService.undoReceiveShipmentItems(
+                shipmentId, request.itemIds(), actor.id(), actor.name());
+        return ResponseEntity.ok(shipmentMapperDecorator.toResponseDTOWithLocationCodes(shipment));
+    }
+
     public record StatusOverrideRequest(ShipmentStatus status, String reason) {}
 
     @PatchMapping("/{id}/status")

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/mappers/AuditLogDTOMapper.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/mappers/AuditLogDTOMapper.java
@@ -41,6 +41,12 @@ public class AuditLogDTOMapper {
                 .notes(auditLog.getNotes())
                 .createdAt(auditLog.getCreatedAt())
                 .productSummary(productSummary)
+                .shipmentId(auditLog.getShipmentId())
+                .shipmentNumber(auditLog.getShipmentNumber())
+                .fieldChanges(auditLog.getFieldChanges())
+                .previousStatus(auditLog.getPreviousStatus())
+                .newStatus(auditLog.getNewStatus())
+                .overrideReason(auditLog.getOverrideReason())
                 .build();
     }
 
@@ -78,6 +84,12 @@ public class AuditLogDTOMapper {
                 .totalQuantityMoved(auditLog.getTotalQuantityMoved())
                 .notes(auditLog.getNotes())
                 .createdAt(auditLog.getCreatedAt())
+                .shipmentId(auditLog.getShipmentId())
+                .shipmentNumber(auditLog.getShipmentNumber())
+                .fieldChanges(auditLog.getFieldChanges())
+                .previousStatus(auditLog.getPreviousStatus())
+                .newStatus(auditLog.getNewStatus())
+                .overrideReason(auditLog.getOverrideReason())
                 .movements(movementDTOs)
                 .build();
     }

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/AuditLogDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/AuditLogDTO.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -30,4 +32,12 @@ public class AuditLogDTO {
 
     // Summary display field (e.g., "Product A" or "3 products")
     private String productSummary;
+
+    // Shipment-event fields (null for inventory-only rows)
+    private UUID shipmentId;
+    private String shipmentNumber;
+    private List<Map<String, Object>> fieldChanges;
+    private String previousStatus;
+    private String newStatus;
+    private String overrideReason;
 }

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/AuditLogDetailDTO.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/dtos/responses/AuditLogDetailDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -28,6 +29,14 @@ public class AuditLogDetailDTO {
     private Integer totalQuantityMoved;
     private String notes;
     private OffsetDateTime createdAt;
+
+    // Shipment-event fields (null for inventory-only rows)
+    private UUID shipmentId;
+    private String shipmentNumber;
+    private List<Map<String, Object>> fieldChanges;
+    private String previousStatus;
+    private String newStatus;
+    private String overrideReason;
 
     // List of all movements in this audit log
     private List<MovementDetailDTO> movements;

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/audit/AuditLog.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/models/audit/AuditLog.java
@@ -8,10 +8,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -68,6 +71,25 @@ public class AuditLog {
 
     @Column(columnDefinition = "TEXT")
     private String notes;
+
+    @Column(name = "shipment_id")
+    private UUID shipmentId;
+
+    @Column(name = "shipment_number", length = 50)
+    private String shipmentNumber;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "field_changes", columnDefinition = "jsonb")
+    private List<Map<String, Object>> fieldChanges;
+
+    @Column(name = "previous_status", length = 50)
+    private String previousStatus;
+
+    @Column(name = "new_status", length = 50)
+    private String newStatus;
+
+    @Column(name = "override_reason", columnDefinition = "TEXT")
+    private String overrideReason;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AuditLogService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/AuditLogService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -127,6 +128,69 @@ public class AuditLogService {
         broadcastService.broadcastAuditLogCreated();
 
         return saved;
+    }
+
+    /**
+     * Create an audit log for a shipment lifecycle event (edit, delete, status override).
+     * Has no associated stock movements; the event detail lives in the structured columns.
+     */
+    @Transactional
+    public AuditLog createShipmentEvent(
+            UUID actorId,
+            String actorName,
+            StockMovementReason reason,
+            UUID shipmentId,
+            String shipmentNumber,
+            int itemCount,
+            List<Map<String, Object>> fieldChanges,
+            String previousStatus,
+            String newStatus,
+            String overrideReason
+    ) {
+        User user = null;
+        if (actorId != null && actorName == null) {
+            user = userRepository.findById(actorId).orElse(null);
+            actorName = user != null ? user.getFullName() : null;
+        }
+
+        AuditLog auditLog = AuditLog.builder()
+                .user(user)
+                .actorName(actorName)
+                .reason(reason)
+                .itemCount(itemCount)
+                .totalQuantityMoved(0)
+                .productSummary(shipmentNumber != null ? "Shipment " + shipmentNumber : null)
+                .shipmentId(shipmentId)
+                .shipmentNumber(shipmentNumber)
+                .fieldChanges(fieldChanges)
+                .previousStatus(previousStatus)
+                .newStatus(newStatus)
+                .overrideReason(overrideReason)
+                .build();
+
+        AuditLog saved = auditLogRepository.save(auditLog);
+        log.info("Created shipment audit log: {} for reason: {} shipment: {}", saved.getId(), reason, shipmentNumber);
+
+        broadcastService.broadcastAuditLogCreated();
+
+        return saved;
+    }
+
+    /**
+     * Persist updates to an existing audit log (e.g., to finalize counts/reason after a multi-item action).
+     */
+    @Transactional
+    public AuditLog save(AuditLog auditLog) {
+        return auditLogRepository.save(auditLog);
+    }
+
+    /**
+     * Delete an audit log (used to discard a parent audit row when a multi-item action turned out
+     * to produce no actual movements — i.e. orphan cleanup, never used for normal history pruning).
+     */
+    @Transactional
+    public void delete(AuditLog auditLog) {
+        auditLogRepository.delete(auditLog);
     }
 
     /**

--- a/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/ShipmentService.java
+++ b/services/inventory-service/src/main/java/com/mirai/inventoryservice/services/ShipmentService.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -407,11 +408,13 @@ public class ShipmentService {
             shipment.setActualDeliveryDate(requestDTO.getActualDeliveryDate());
         }
 
-        // Issue 7 fix: Resolve actor ID once before the loop
+        // Resolve receiving user once up front (used for both shipment.receivedBy and the audit log actor)
+        User receivedByUser = null;
         UUID validatedActorId = null;
         if (requestDTO.getReceivedBy() != null) {
-            if (userRepository.findById(requestDTO.getReceivedBy()).isPresent()) {
-                validatedActorId = requestDTO.getReceivedBy();
+            receivedByUser = userRepository.findById(requestDTO.getReceivedBy()).orElse(null);
+            if (receivedByUser != null) {
+                validatedActorId = receivedByUser.getId();
             }
         }
 
@@ -427,6 +430,21 @@ public class ShipmentService {
         // Track what was received in this batch for audit
         List<String> receivedItemSummaries = new ArrayList<>();
         int totalReceivedInBatch = 0;
+
+        // Create the parent audit log up front; its reason / counts are finalized after the loop.
+        // All per-item stock movements get linked to this single audit log, mirroring the transfer pattern.
+        AuditLog receiveAuditLog = auditLogService.createAuditLog(
+                validatedActorId,
+                receivedByUser != null ? receivedByUser.getFullName() : null,
+                StockMovementReason.SHIPMENT_PARTIAL_RECEIPT,
+                null, null, null, null,
+                0,
+                0,
+                "Shipment " + shipment.getShipmentNumber(),
+                null
+        );
+        receiveAuditLog.setShipmentId(shipment.getId());
+        receiveAuditLog.setShipmentNumber(shipment.getShipmentNumber());
 
         for (ReceiveShipmentRequestDTO.ItemReceiptDTO receipt : requestDTO.getItemReceipts()) {
             ShipmentItem shipmentItem = shipmentItemMap.get(receipt.getShipmentItemId());
@@ -572,8 +590,7 @@ public class ShipmentService {
                             shipmentItem.getItem(),
                             allocQty,
                             validatedActorId,
-                            shipment.getShipmentNumber(),
-                            shipment.getId()
+                            receiveAuditLog
                     );
                 } else {
                     // Add to regular location inventory
@@ -582,7 +599,8 @@ public class ShipmentService {
                             locationId,
                             shipmentItem.getItem(),
                             allocQty,
-                            validatedActorId
+                            validatedActorId,
+                            receiveAuditLog
                     );
                 }
             }
@@ -642,29 +660,24 @@ public class ShipmentService {
             notificationService.createNotification(completionNotif);
         }
 
-        // Set receivedBy if provided
-        User receivedByUser = null;
-        if (requestDTO.getReceivedBy() != null) {
-            receivedByUser = userRepository.findById(requestDTO.getReceivedBy()).orElse(null);
-            if (receivedByUser != null) {
-                shipment.setReceivedBy(receivedByUser);
-            }
+        // Set receivedBy on the shipment if a receiver was provided (user already resolved up front)
+        if (receivedByUser != null) {
+            shipment.setReceivedBy(receivedByUser);
         }
 
         Shipment savedShipment = shipmentRepository.save(shipment);
 
-        // Create partial receipt audit if anything was received
-        if (!receivedItemSummaries.isEmpty()) {
-            UUID auditActorId = receivedByUser != null ? receivedByUser.getId() : validatedActorId;
-            String auditActorName = receivedByUser != null ? receivedByUser.getFullName() : null;
-            createPartialReceiptAudit(
-                    savedShipment,
-                    receivedItemSummaries,
-                    totalReceivedInBatch,
-                    allItemsFullyReceived,
-                    auditActorId,
-                    auditActorName
-            );
+        // Finalize the parent audit log: set the right reason and aggregate counts based on what
+        // actually got received. If nothing did, drop the orphan row entirely.
+        if (receivedItemSummaries.isEmpty()) {
+            auditLogService.delete(receiveAuditLog);
+        } else {
+            receiveAuditLog.setReason(allItemsFullyReceived
+                    ? StockMovementReason.SHIPMENT_RECEIPT
+                    : StockMovementReason.SHIPMENT_PARTIAL_RECEIPT);
+            receiveAuditLog.setItemCount(receivedItemSummaries.size());
+            receiveAuditLog.setTotalQuantityMoved(totalReceivedInBatch);
+            auditLogService.save(receiveAuditLog);
         }
 
         // Ensure product quantity/isActive denormalized fields stay in sync for UI reads
@@ -693,53 +706,110 @@ public class ShipmentService {
      * @throws InsufficientInventoryException if inventory has been depleted
      */
     public Shipment undoReceiveShipmentItem(UUID shipmentId, UUID itemId, UUID actorId, String actorName) {
+        return undoReceiveShipmentItems(shipmentId, List.of(itemId), actorId, actorName);
+    }
+
+    /**
+     * Reverse receipt of one or more shipment items in a single transaction. Treats the whole
+     * batch as one user action: produces exactly one parent AuditLog (reason SHIPMENT_RECEIPT_REVERSED)
+     * with N stock movement rows under it, mirroring how receiveShipment / batchTransferInventory work.
+     */
+    public Shipment undoReceiveShipmentItems(UUID shipmentId, List<UUID> itemIds, UUID actorId, String actorName) {
+        if (itemIds == null || itemIds.isEmpty()) {
+            throw new IllegalArgumentException("itemIds must not be empty");
+        }
+
         Shipment shipment = getShipmentById(shipmentId);
 
-        // Find the shipment item
-        ShipmentItem shipmentItem = shipment.getItems().stream()
-                .filter(item -> item.getId().equals(itemId))
-                .findFirst()
-                .orElseThrow(() -> new ShipmentItemNotFoundException(
-                        "Shipment item " + itemId + " not found in shipment " + shipmentId));
+        // Resolve every requested shipment item up front and validate it belongs to this shipment
+        // and has something to undo. We fail the entire batch on the first invalid item — the user
+        // explicitly selected each one, so partial-failure semantics would be confusing.
+        List<ShipmentItem> targets = new ArrayList<>(itemIds.size());
+        for (UUID itemId : itemIds) {
+            ShipmentItem shipmentItem = shipment.getItems().stream()
+                    .filter(it -> it.getId().equals(itemId))
+                    .findFirst()
+                    .orElseThrow(() -> new ShipmentItemNotFoundException(
+                            "Shipment item " + itemId + " not found in shipment " + shipmentId));
 
-        // Validate item has something to undo
-        boolean hasReceivedQuantities = shipmentItem.getReceivedQuantity() > 0
-                || shipmentItem.getDamagedQuantity() > 0
-                || shipmentItem.getDisplayQuantity() > 0
-                || shipmentItem.getShopQuantity() > 0;
-        boolean hasAllocations = !shipmentItem.getAllocations().isEmpty();
-
-        if (!hasReceivedQuantities && !hasAllocations) {
-            throw new InvalidShipmentStatusException(
-                    "Shipment item has not been received yet. Nothing to undo.");
-        }
-
-        Product product = shipmentItem.getItem();
-        String shipmentNumber = shipment.getShipmentNumber();
-        Set<UUID> affectedProductIds = new java.util.HashSet<>();
-        affectedProductIds.add(product.getId());
-
-        // Reverse each allocation (same logic as undoReceiveShipment)
-        for (ShipmentItemAllocation allocation : shipmentItem.getAllocations()) {
-            LocationType locationType = allocation.getLocationType();
-            UUID locationId = allocation.getLocationId();
-            int quantity = allocation.getQuantity();
-
-            if (locationType == LocationType.NOT_ASSIGNED || locationId == null) {
-                removeFromNotAssignedInventory(product, quantity, actorId, actorName, shipmentNumber);
-            } else {
-                removeFromInventory(locationType, locationId, product, quantity, actorId, actorName, shipmentNumber);
+            boolean hasReceivedQuantities = shipmentItem.getReceivedQuantity() > 0
+                    || shipmentItem.getDamagedQuantity() > 0
+                    || shipmentItem.getDisplayQuantity() > 0
+                    || shipmentItem.getShopQuantity() > 0;
+            boolean hasAllocations = !shipmentItem.getAllocations().isEmpty();
+            if (!hasReceivedQuantities && !hasAllocations) {
+                throw new InvalidShipmentStatusException(
+                        "Shipment item " + itemId + " has not been received yet. Nothing to undo.");
             }
+            targets.add(shipmentItem);
         }
 
-        // Clear allocations (orphanRemoval will delete them)
-        shipmentItem.getAllocations().clear();
+        Set<UUID> affectedProductIds = new java.util.HashSet<>();
+        for (ShipmentItem t : targets) {
+            affectedProductIds.add(t.getItem().getId());
+        }
 
-        // Reset quantities for this item only
-        shipmentItem.setReceivedQuantity(0);
-        shipmentItem.setDamagedQuantity(0);
-        shipmentItem.setDisplayQuantity(0);
-        shipmentItem.setShopQuantity(0);
+        // Total quantity reversed across all selected items, used for the audit row's display values.
+        int totalReversed = targets.stream()
+                .flatMap(t -> t.getAllocations().stream())
+                .mapToInt(ShipmentItemAllocation::getQuantity)
+                .sum();
+
+        // Create the single parent audit log up front. Even if no allocations exist (only
+        // damaged/display/shop quantities), we still want a single audit row representing
+        // the reversal action.
+        AuditLog reverseAuditLog = auditLogService.createAuditLog(
+                actorId,
+                actorName,
+                StockMovementReason.SHIPMENT_RECEIPT_REVERSED,
+                null, null, null, null,
+                targets.size(),
+                totalReversed,
+                "Shipment " + shipment.getShipmentNumber(),
+                null
+        );
+        reverseAuditLog.setShipmentId(shipment.getId());
+        reverseAuditLog.setShipmentNumber(shipment.getShipmentNumber());
+        auditLogService.save(reverseAuditLog);
+
+        // Now process each item under the single parent audit log
+        for (ShipmentItem shipmentItem : targets) {
+            Product product = shipmentItem.getItem();
+
+            // Multiple partial-receives leave one allocation row per receive event, even
+            // when they target the same location. Sum them per (locationType, locationId)
+            // so the reversal emits one stock movement per location bucket — otherwise
+            // the audit log shows the same product twice (e.g. 2->1 then 1->0) for what
+            // is conceptually a single -2 reversal.
+            Map<AllocationBucketKey, Integer> bucketedQuantities = new LinkedHashMap<>();
+            for (ShipmentItemAllocation allocation : shipmentItem.getAllocations()) {
+                LocationType locationType = allocation.getLocationType();
+                UUID locationId = allocation.getLocationId();
+                AllocationBucketKey key = (locationType == LocationType.NOT_ASSIGNED || locationId == null)
+                        ? AllocationBucketKey.NOT_ASSIGNED
+                        : new AllocationBucketKey(locationType, locationId);
+                bucketedQuantities.merge(key, allocation.getQuantity(), Integer::sum);
+            }
+
+            for (Map.Entry<AllocationBucketKey, Integer> entry : bucketedQuantities.entrySet()) {
+                AllocationBucketKey key = entry.getKey();
+                int quantity = entry.getValue();
+                if (key.locationId() == null) {
+                    removeFromNotAssignedInventory(product, quantity, actorId, reverseAuditLog);
+                } else {
+                    removeFromInventory(key.locationType(), key.locationId(), product, quantity, actorId, reverseAuditLog);
+                }
+            }
+
+            // Clear allocations (orphanRemoval will delete them)
+            shipmentItem.getAllocations().clear();
+
+            // Reset quantities for this item
+            shipmentItem.setReceivedQuantity(0);
+            shipmentItem.setDamagedQuantity(0);
+            shipmentItem.setDisplayQuantity(0);
+            shipmentItem.setShopQuantity(0);
+        }
 
         // Recompute status from item math. Undo is an explicit reversal -
         // if the remaining items no longer satisfy the fully-received check, drop back to PENDING.
@@ -794,17 +864,17 @@ public class ShipmentService {
         shipment.setStatus(newStatus);
         Shipment savedShipment = shipmentRepository.save(shipment);
 
-        String notesText = String.format("Status override: %s -> %s. Reason: %s",
-                oldStatus, newStatus, reason.trim());
-        auditLogService.createAuditLog(
+        auditLogService.createShipmentEvent(
                 actorId,
                 actorName,
                 StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN,
-                null, null, null, null,
+                shipment.getId(),
+                shipment.getShipmentNumber(),
                 1,
-                0,
-                "Shipment " + shipment.getShipmentNumber(),
-                notesText
+                null,
+                oldStatus.name(),
+                newStatus.name(),
+                reason.trim()
         );
 
         broadcastService.broadcastShipmentUpdated();
@@ -815,8 +885,9 @@ public class ShipmentService {
 
     /**
      * Add inventory to a location using the unified location_inventory table.
+     * The caller passes the parent audit log; this method only writes a stock movement under it.
      */
-    private void addToInventory(LocationType locationType, UUID locationId, Product product, int quantity, UUID validatedActorId) {
+    private void addToInventory(LocationType locationType, UUID locationId, Product product, int quantity, UUID validatedActorId, AuditLog parentAuditLog) {
         Location location = locationRepository.findById(locationId)
                 .orElseThrow(() -> new LocationNotFoundException("Location not found: " + locationId));
 
@@ -837,26 +908,12 @@ public class ShipmentService {
         LocationInventory saved = locationInventoryRepository.save(inventory);
         int currentQuantity = saved.getQuantity();
 
-        String toLocationCode = location.getLocationCode();
-        AuditLog auditLog = auditLogService.createAuditLog(
-                validatedActorId,
-                StockMovementReason.SHIPMENT_RECEIPT,
-                null,
-                null,
-                locationId,
-                toLocationCode,
-                1,
-                quantity,
-                product.getName(),
-                null
-        );
-
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("inventory_id", saved.getId().toString());
         metadata.put("shipment_receipt", true);
 
         StockMovement movement = StockMovement.builder()
-                .auditLog(auditLog)
+                .auditLog(parentAuditLog)
                 .item(product)
                 .locationType(locationType)
                 .toLocationId(locationId)
@@ -875,8 +932,9 @@ public class ShipmentService {
 
     /**
      * Add inventory to NOT_ASSIGNED location using the unified location_inventory table.
+     * The caller passes the parent audit log; this method only writes a stock movement under it.
      */
-    private void addToNotAssignedInventory(Product product, int quantity, UUID validatedActorId, String shipmentNumber, UUID shipmentId) {
+    private void addToNotAssignedInventory(Product product, int quantity, UUID validatedActorId, AuditLog parentAuditLog) {
         // Get NOT_ASSIGNED location
         Location notAssignedLocation = getNotAssignedLocation();
 
@@ -894,25 +952,12 @@ public class ShipmentService {
         LocationInventory saved = locationInventoryRepository.save(inventory);
         int currentQuantity = saved.getQuantity();
 
-        AuditLog auditLog = auditLogService.createAuditLog(
-                validatedActorId,
-                StockMovementReason.SHIPMENT_RECEIPT,
-                null,
-                null,
-                notAssignedLocation.getId(),
-                "NA",
-                1,
-                quantity,
-                product.getName(),
-                null
-        );
-
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("inventory_id", saved.getId().toString());
         metadata.put("shipment_receipt", true);
 
         StockMovement movement = StockMovement.builder()
-                .auditLog(auditLog)
+                .auditLog(parentAuditLog)
                 .item(product)
                 .locationType(LocationType.NOT_ASSIGNED)
                 .toLocationId(notAssignedLocation.getId())
@@ -942,10 +987,11 @@ public class ShipmentService {
 
     /**
      * Remove quantity from inventory at a specific location (for undo operations).
-     * Uses the unified location_inventory table.
+     * Uses the unified location_inventory table. The caller passes the parent audit log; this method
+     * only writes a stock movement under it.
      */
     private void removeFromInventory(LocationType locationType, UUID locationId, Product product, int quantity,
-                                     UUID actorId, String actorName, String shipmentNumber) {
+                                     UUID actorId, AuditLog parentAuditLog) {
         LocationInventory inventory = locationInventoryRepository
                 .findByLocation_IdAndProduct_Id(locationId, product.getId())
                 .orElseThrow(() -> new InsufficientInventoryException(
@@ -963,29 +1009,13 @@ public class ShipmentService {
         }
 
         int newQuantity = currentQuantity - quantity;
-        String locationCode = inventory.getLocation().getLocationCode();
-
-        // Create audit log for reversal
-        AuditLog auditLog = auditLogService.createAuditLog(
-                actorId,
-                actorName,
-                StockMovementReason.SHIPMENT_RECEIPT_REVERSED,
-                locationId,
-                locationCode,
-                null,
-                null,
-                1,
-                quantity,
-                product.getName(),
-                String.format("Reversed receipt for %s from shipment %s", product.getName(), shipmentNumber)
-        );
 
         // Create stock movement record
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("shipment_receipt_reversal", true);
 
         StockMovement movement = StockMovement.builder()
-                .auditLog(auditLog)
+                .auditLog(parentAuditLog)
                 .item(product)
                 .locationType(locationType)
                 .fromLocationId(locationId)
@@ -1012,10 +1042,11 @@ public class ShipmentService {
 
     /**
      * Remove quantity from NOT_ASSIGNED inventory (for undo operations).
-     * Uses the unified location_inventory table.
+     * Uses the unified location_inventory table. The caller passes the parent audit log; this method
+     * only writes a stock movement under it.
      */
     private void removeFromNotAssignedInventory(Product product, int quantity,
-                                                UUID actorId, String actorName, String shipmentNumber) {
+                                                UUID actorId, AuditLog parentAuditLog) {
         Location notAssignedLocation = getNotAssignedLocation();
 
         LocationInventory inventory = locationInventoryRepository
@@ -1036,27 +1067,12 @@ public class ShipmentService {
 
         int newQuantity = currentQuantity - quantity;
 
-        // Create audit log
-        AuditLog auditLog = auditLogService.createAuditLog(
-                actorId,
-                actorName,
-                StockMovementReason.SHIPMENT_RECEIPT_REVERSED,
-                notAssignedLocation.getId(),
-                "NA",
-                null,
-                null,
-                1,
-                quantity,
-                product.getName(),
-                String.format("Reversed receipt for %s from shipment %s", product.getName(), shipmentNumber)
-        );
-
         // Create stock movement
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("shipment_receipt_reversal", true);
 
         StockMovement movement = StockMovement.builder()
-                .auditLog(auditLog)
+                .auditLog(parentAuditLog)
                 .item(product)
                 .locationType(LocationType.NOT_ASSIGNED)
                 .fromLocationId(notAssignedLocation.getId())
@@ -1167,7 +1183,7 @@ public class ShipmentService {
     }
 
     /**
-     * Create audit log for shipment edit, capturing all changes
+     * Create audit log for shipment edit, capturing all changes as a structured field_changes JSON array.
      */
     private void createShipmentEditAudit(
             Shipment shipment,
@@ -1176,162 +1192,140 @@ public class ShipmentService {
             UUID actorId,
             String actorName
     ) {
-        List<String> changes = new ArrayList<>();
+        List<Map<String, Object>> changes = new ArrayList<>();
 
         // Compare scalar fields
         if (!java.util.Objects.equals(before.supplierName(), after.supplierName())) {
-            changes.add("Supplier: " + nvl(before.supplierName()) + " -> " + nvl(after.supplierName()));
+            changes.add(fieldChange("supplier", before.supplierName(), after.supplierName()));
         }
         if (!java.util.Objects.equals(before.shipmentNumber(), after.shipmentNumber())) {
-            changes.add("Number: " + nvl(before.shipmentNumber()) + " -> " + nvl(after.shipmentNumber()));
+            changes.add(fieldChange("shipmentNumber", before.shipmentNumber(), after.shipmentNumber()));
         }
         if (!java.util.Objects.equals(before.status(), after.status())) {
-            changes.add("Status: " + before.status() + " -> " + after.status());
+            changes.add(fieldChange("status",
+                    before.status() != null ? before.status().name() : null,
+                    after.status() != null ? after.status().name() : null));
         }
         if (!java.util.Objects.equals(before.orderDate(), after.orderDate())) {
-            changes.add("Order Date: " + nvl(before.orderDate()) + " -> " + nvl(after.orderDate()));
+            changes.add(fieldChange("orderDate",
+                    before.orderDate() != null ? before.orderDate().toString() : null,
+                    after.orderDate() != null ? after.orderDate().toString() : null));
         }
         if (!java.util.Objects.equals(before.expectedDeliveryDate(), after.expectedDeliveryDate())) {
-            changes.add("Expected Date: " + nvl(before.expectedDeliveryDate()) + " -> " + nvl(after.expectedDeliveryDate()));
+            changes.add(fieldChange("expectedDeliveryDate",
+                    before.expectedDeliveryDate() != null ? before.expectedDeliveryDate().toString() : null,
+                    after.expectedDeliveryDate() != null ? after.expectedDeliveryDate().toString() : null));
         }
         if (!java.util.Objects.equals(before.actualDeliveryDate(), after.actualDeliveryDate())) {
-            changes.add("Actual Date: " + nvl(before.actualDeliveryDate()) + " -> " + nvl(after.actualDeliveryDate()));
+            changes.add(fieldChange("actualDeliveryDate",
+                    before.actualDeliveryDate() != null ? before.actualDeliveryDate().toString() : null,
+                    after.actualDeliveryDate() != null ? after.actualDeliveryDate().toString() : null));
         }
         if (!bigDecimalEquals(before.totalCost(), after.totalCost())) {
-            changes.add("Cost: " + nvl(before.totalCost()) + " -> " + nvl(after.totalCost()));
+            changes.add(fieldChange("totalCost",
+                    before.totalCost() != null ? before.totalCost().toPlainString() : null,
+                    after.totalCost() != null ? after.totalCost().toPlainString() : null));
         }
         if (!java.util.Objects.equals(before.trackingId(), after.trackingId())) {
-            changes.add("Tracking: " + nvl(before.trackingId()) + " -> " + nvl(after.trackingId()));
+            changes.add(fieldChange("trackingId", before.trackingId(), after.trackingId()));
         }
         if (!java.util.Objects.equals(before.notes(), after.notes())) {
-            changes.add("Notes updated");
+            // Don't reveal note contents in the audit log; just record that they changed.
+            Map<String, Object> notesEntry = new HashMap<>();
+            notesEntry.put("field", "notes");
+            notesEntry.put("changed", true);
+            changes.add(notesEntry);
         }
 
         // Compare items
         Set<UUID> beforeProductIds = before.items().stream().map(ItemSnapshot::productId).collect(Collectors.toSet());
         Set<UUID> afterProductIds = after.items().stream().map(ItemSnapshot::productId).collect(Collectors.toSet());
 
-        List<String> addedItems = after.items().stream()
+        List<Map<String, Object>> addedItems = after.items().stream()
                 .filter(item -> !beforeProductIds.contains(item.productId()))
-                .map(item -> item.productName() + " (" + item.orderedQuantity() + ")")
-                .toList();
+                .map(item -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("name", item.productName());
+                    m.put("qty", item.orderedQuantity());
+                    return m;
+                })
+                .collect(Collectors.toList());
 
-        List<String> removedItems = before.items().stream()
+        List<Map<String, Object>> removedItems = before.items().stream()
                 .filter(item -> !afterProductIds.contains(item.productId()))
-                .map(item -> item.productName() + " (" + item.orderedQuantity() + ")")
-                .toList();
+                .map(item -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("name", item.productName());
+                    m.put("qty", item.orderedQuantity());
+                    return m;
+                })
+                .collect(Collectors.toList());
 
         if (!addedItems.isEmpty()) {
-            changes.add("Added: " + String.join(", ", addedItems));
+            changes.add(fieldChange("items_added", null, addedItems));
         }
         if (!removedItems.isEmpty()) {
-            changes.add("Removed: " + String.join(", ", removedItems));
+            changes.add(fieldChange("items_removed", removedItems, null));
         }
 
-        // Only create audit if there were actual changes
         if (changes.isEmpty()) {
             return;
         }
 
-        String notesText = String.join(". ", changes);
-
-        auditLogService.createAuditLog(
+        auditLogService.createShipmentEvent(
                 actorId,
                 actorName,
                 StockMovementReason.SHIPMENT_EDITED,
-                null, null, null, null,
+                shipment.getId(),
+                shipment.getShipmentNumber(),
                 1,
-                0,
-                "Shipment " + shipment.getShipmentNumber(),
-                notesText
+                changes,
+                null,
+                null,
+                null
         );
     }
 
+    private static Map<String, Object> fieldChange(String field, Object from, Object to) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("field", field);
+        entry.put("from", from);
+        entry.put("to", to);
+        return entry;
+    }
+
     /**
-     * Create audit log for shipment deletion, capturing full details
+     * Create audit log for shipment deletion, capturing full details as structured JSON.
      */
     private void createShipmentDeletionAudit(Shipment shipment, UUID actorId, String actorName) {
-        // Build summary of items being deleted
-        String itemsSummary = shipment.getItems().stream()
+        List<Map<String, Object>> deletedItems = shipment.getItems().stream()
                 .map(item -> {
-                    int ordered = item.getOrderedQuantity() != null ? item.getOrderedQuantity() : 0;
-                    int received = item.getReceivedQuantity() != null ? item.getReceivedQuantity() : 0;
-                    String name = item.getItem().getName();
-                    if (received > 0) {
-                        return name + " (ordered: " + ordered + ", received: " + received + ")";
-                    }
-                    return name + " (ordered: " + ordered + ")";
+                    Map<String, Object> entry = new HashMap<>();
+                    entry.put("name", item.getItem().getName());
+                    entry.put("ordered", item.getOrderedQuantity() != null ? item.getOrderedQuantity() : 0);
+                    entry.put("received", item.getReceivedQuantity() != null ? item.getReceivedQuantity() : 0);
+                    return entry;
                 })
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.toList());
 
-        String notesText = String.format(
-                "Deleted shipment %s from %s. Items: %s",
-                shipment.getShipmentNumber(),
-                nvl(shipment.getSupplierName()),
-                itemsSummary.isEmpty() ? "none" : itemsSummary
-        );
+        List<Map<String, Object>> changes = new ArrayList<>();
+        Map<String, Object> supplierEntry = new HashMap<>();
+        supplierEntry.put("field", "supplier");
+        supplierEntry.put("value", shipment.getSupplierName());
+        changes.add(supplierEntry);
+        changes.add(fieldChange("deleted_items", null, deletedItems));
 
-        auditLogService.createAuditLog(
+        auditLogService.createShipmentEvent(
                 actorId,
                 actorName,
                 StockMovementReason.SHIPMENT_DELETED,
-                null, null, null, null,
+                shipment.getId(),
+                shipment.getShipmentNumber(),
                 shipment.getItems().size(),
-                0,
-                "Shipment " + shipment.getShipmentNumber() + " (deleted)",
-                notesText
-        );
-    }
-
-    /**
-     * Create audit log for partial receipt
-     */
-    private void createPartialReceiptAudit(
-            Shipment shipment,
-            List<String> receivedItemSummaries,
-            int totalReceivedInBatch,
-            boolean isComplete,
-            UUID actorId,
-            String actorName
-    ) {
-        // Build remaining items summary
-        List<String> remainingItems = new ArrayList<>();
-        for (ShipmentItem item : shipment.getItems()) {
-            int ordered = item.getOrderedQuantity() != null ? item.getOrderedQuantity() : 0;
-            int received = item.getReceivedQuantity() != null ? item.getReceivedQuantity() : 0;
-            int damaged = item.getDamagedQuantity() != null ? item.getDamagedQuantity() : 0;
-            int display = item.getDisplayQuantity() != null ? item.getDisplayQuantity() : 0;
-            int shop = item.getShopQuantity() != null ? item.getShopQuantity() : 0;
-            int accountedFor = received + damaged + display + shop;
-            int remaining = ordered - accountedFor;
-            if (remaining > 0) {
-                remainingItems.add(item.getItem().getName() + " (" + remaining + ")");
-            }
-        }
-
-        StockMovementReason reason = isComplete
-                ? StockMovementReason.SHIPMENT_RECEIPT
-                : StockMovementReason.SHIPMENT_PARTIAL_RECEIPT;
-
-        String notesText;
-        if (isComplete) {
-            notesText = "Shipment fully received. Received: " + String.join(", ", receivedItemSummaries);
-        } else {
-            notesText = "Received: " + String.join(", ", receivedItemSummaries);
-            if (!remainingItems.isEmpty()) {
-                notesText += ". Remaining: " + String.join(", ", remainingItems);
-            }
-        }
-
-        auditLogService.createAuditLog(
-                actorId,
-                actorName,
-                reason,
-                null, null, null, null,
-                receivedItemSummaries.size(),
-                totalReceivedInBatch,
-                "Shipment " + shipment.getShipmentNumber(),
-                notesText
+                changes,
+                null,
+                null,
+                null
         );
     }
 
@@ -1347,5 +1341,9 @@ public class ShipmentService {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
         return a.compareTo(b) == 0;
+    }
+
+    private record AllocationBucketKey(LocationType locationType, UUID locationId) {
+        static final AllocationBucketKey NOT_ASSIGNED = new AllocationBucketKey(LocationType.NOT_ASSIGNED, null);
     }
 }

--- a/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/AuditLogServiceShipmentEventTest.java
+++ b/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/AuditLogServiceShipmentEventTest.java
@@ -1,0 +1,131 @@
+package com.mirai.inventoryservice.services;
+
+import com.mirai.inventoryservice.dtos.mappers.AuditLogDTOMapper;
+import com.mirai.inventoryservice.models.audit.AuditLog;
+import com.mirai.inventoryservice.models.enums.StockMovementReason;
+import com.mirai.inventoryservice.repositories.AuditLogRepository;
+import com.mirai.inventoryservice.repositories.StockMovementRepository;
+import com.mirai.inventoryservice.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that the new createShipmentEvent path writes structured shipment columns
+ * (shipment_id, shipment_number, field_changes, previous_status, new_status, override_reason)
+ * onto the AuditLog entity instead of stuffing details into the notes blob.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AuditLogServiceShipmentEventTest {
+
+    @Mock private AuditLogRepository auditLogRepository;
+    @Mock private StockMovementRepository stockMovementRepository;
+    @Mock private AuditLogDTOMapper auditLogMapper;
+    @Mock private UserRepository userRepository;
+    @Mock private SupabaseBroadcastService broadcastService;
+
+    private AuditLogService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AuditLogService(
+                auditLogRepository, stockMovementRepository, auditLogMapper, userRepository, broadcastService);
+        when(auditLogRepository.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void statusOverrideWritesStructuredColumns() {
+        UUID shipmentId = UUID.randomUUID();
+        UUID actor = UUID.randomUUID();
+
+        service.createShipmentEvent(
+                actor, "Bob",
+                StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN,
+                shipmentId, "SHIP-123",
+                1,
+                null,
+                "PENDING", "RECEIVED",
+                "missing tracking; items received");
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        AuditLog saved = captor.getValue();
+
+        assertEquals(StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN, saved.getReason());
+        assertEquals(shipmentId, saved.getShipmentId());
+        assertEquals("SHIP-123", saved.getShipmentNumber());
+        assertEquals("PENDING", saved.getPreviousStatus());
+        assertEquals("RECEIVED", saved.getNewStatus());
+        assertEquals("missing tracking; items received", saved.getOverrideReason());
+        assertNull(saved.getFieldChanges(), "status override should not set field_changes");
+        assertNull(saved.getNotes(), "structured columns replace prose notes");
+        assertEquals("Shipment SHIP-123", saved.getProductSummary());
+    }
+
+    @Test
+    void shipmentEditWritesFieldChangesArray() {
+        UUID shipmentId = UUID.randomUUID();
+
+        Map<String, Object> supplierChange = new HashMap<>();
+        supplierChange.put("field", "supplier");
+        supplierChange.put("from", "Acme");
+        supplierChange.put("to", "Globex");
+
+        Map<String, Object> statusChange = new HashMap<>();
+        statusChange.put("field", "status");
+        statusChange.put("from", "PENDING");
+        statusChange.put("to", "RECEIVED");
+
+        List<Map<String, Object>> fieldChanges = List.of(supplierChange, statusChange);
+
+        service.createShipmentEvent(
+                null, "Alice",
+                StockMovementReason.SHIPMENT_EDITED,
+                shipmentId, "SHIP-9",
+                1,
+                fieldChanges,
+                null, null, null);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        AuditLog saved = captor.getValue();
+
+        assertEquals(StockMovementReason.SHIPMENT_EDITED, saved.getReason());
+        assertEquals(shipmentId, saved.getShipmentId());
+        assertEquals("SHIP-9", saved.getShipmentNumber());
+        assertNotNull(saved.getFieldChanges());
+        assertEquals(2, saved.getFieldChanges().size());
+        assertEquals("supplier", saved.getFieldChanges().get(0).get("field"));
+        assertEquals("status", saved.getFieldChanges().get(1).get("field"));
+        assertNull(saved.getPreviousStatus(),
+                "edit form changes go in field_changes, not the dedicated previous_status column");
+        assertNull(saved.getNewStatus());
+    }
+
+    @Test
+    void broadcastsAfterCreate() {
+        service.createShipmentEvent(
+                null, null,
+                StockMovementReason.SHIPMENT_DELETED,
+                UUID.randomUUID(), "SHIP-1",
+                3,
+                List.of(),
+                null, null, null);
+        verify(broadcastService).broadcastAuditLogCreated();
+    }
+}

--- a/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/ShipmentServiceOverrideTest.java
+++ b/services/inventory-service/src/test/java/com/mirai/inventoryservice/services/ShipmentServiceOverrideTest.java
@@ -1,7 +1,6 @@
 package com.mirai.inventoryservice.services;
 
 import com.mirai.inventoryservice.exceptions.InvalidShipmentStatusException;
-import com.mirai.inventoryservice.models.audit.AuditLog;
 import com.mirai.inventoryservice.models.enums.ShipmentStatus;
 import com.mirai.inventoryservice.models.enums.StockMovementReason;
 import com.mirai.inventoryservice.models.shipment.Shipment;
@@ -9,7 +8,6 @@ import com.mirai.inventoryservice.repositories.ShipmentRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -22,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -84,12 +83,27 @@ class ShipmentServiceOverrideTest {
                 shipmentId, ShipmentStatus.RECEIVED, "missing tracking, items received", actor, "Bob");
 
         assertEquals(ShipmentStatus.RECEIVED, result.getStatus());
-        ArgumentCaptor<String> notes = ArgumentCaptor.forClass(String.class);
-        verify(auditLogService).createAuditLog(
+        verify(auditLogService).createShipmentEvent(
                 eq(actor), eq("Bob"), eq(StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN),
-                any(), any(), any(), any(), anyInt(), anyInt(), any(), notes.capture());
-        assertTrue(notes.getValue().contains("PENDING -> RECEIVED"));
-        assertTrue(notes.getValue().contains("missing tracking, items received"));
+                eq(shipmentId), eq("SHIP-1"), eq(1),
+                isNull(),
+                eq("PENDING"),
+                eq("RECEIVED"),
+                eq("missing tracking, items received"));
+        // The legacy createAuditLog path is no longer called for overrides.
+        verify(auditLogService, never()).createAuditLog(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyInt(), any(), any());
+    }
+
+    @Test
+    void overrideTrimsReasonWhitespace() {
+        shipmentWith(ShipmentStatus.PENDING);
+        service.overrideShipmentStatus(
+                shipmentId, ShipmentStatus.RECEIVED, "  padded reason  ", null, null);
+        verify(auditLogService).createShipmentEvent(
+                any(), any(), eq(StockMovementReason.SHIPMENT_STATUS_OVERRIDDEN),
+                any(), any(), anyInt(), any(), any(), any(),
+                eq("padded reason"));
     }
 
     @Test
@@ -99,8 +113,8 @@ class ShipmentServiceOverrideTest {
                 service.overrideShipmentStatus(
                         shipmentId, ShipmentStatus.CANCELLED, "trying to cancel", null, null));
         verify(shipmentRepository, never()).save(any());
-        verify(auditLogService, never()).createAuditLog(any(), any(), any(), any(), any(), any(), any(),
-                anyInt(), anyInt(), any(), any());
+        verify(auditLogService, never()).createShipmentEvent(any(), any(), any(), any(), any(),
+                anyInt(), any(), any(), any(), any());
     }
 
     @Test
@@ -119,8 +133,8 @@ class ShipmentServiceOverrideTest {
         service.overrideShipmentStatus(
                 shipmentId, ShipmentStatus.RECEIVED, "no change", null, null);
         verify(shipmentRepository, never()).save(any());
-        verify(auditLogService, never()).createAuditLog(any(), any(), any(), any(), any(), any(), any(),
-                anyInt(), anyInt(), any(), any());
+        verify(auditLogService, never()).createShipmentEvent(any(), any(), any(), any(), any(),
+                anyInt(), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
- Capture structured shipment lifecycle events (edited, deleted, status override) on AuditLog with new columns and DTO fields, plus expanded-row detail components on the audit log table
- Add /shipments/{id}/items/undo bulk endpoint and wire frontend undo dialog + mutations to call it
- Fix shipment reversal showing the same product on multiple rows: in undoReceiveShipmentItems, group allocations by (locationType, locationId) per item so each location bucket emits one stock movement, not one per partial-receive allocation row
- Add migration 08-shipment-audit-columns.sql for the new audit columns
- Add AuditLogServiceShipmentEventTest; update ShipmentServiceOverrideTest